### PR TITLE
Phase 1: Onboarding backfill (Deel → Firestore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Onboarding: shared modules copied from Payroll at deploy (single source of truth)
+Onboarding/matcher.py
+Onboarding/deel_client.py

--- a/Onboarding/README.md
+++ b/Onboarding/README.md
@@ -1,0 +1,230 @@
+# Onboarding / Offboarding Automation
+
+Automates developer **onboarding** and **offboarding** end to end, replacing a
+manual process. This README covers **Phase 1** (the Firestore store, email/name
+logic, and an idempotent Deel→Firestore backfill). Provisioning, the Slack
+approval endpoint, the activation poller, offboarding and the dashboard are later
+phases and intentionally **not** built yet.
+
+## State store — why Firestore (not SQLite-on-GCS)
+
+Onboarding is **event-driven**: a Slack approval button, an activation poller, and
+the Deel poll can all touch the same hire concurrently. The payroll
+download→modify→upload SQLite-on-GCS pattern would clobber concurrent writes.
+Firestore is serverless and concurrent-safe; every mutating op in
+`firestore_store.py` runs in a **transaction**.
+
+- Collection: `onboarding`, **one doc per hire, keyed by the Deel `person_id`**.
+
+### Document shape
+
+```
+person_id; contract_name; personal_name; email; name_confidence (high|medium|low);
+lifecycle (gated|needs_approval|provisioning|not_signed_in|active|offboarding|offboarded);
+start_date; backfill_back_catalog (bool);
+accounts: { zoho:{created_at,activated_at}, slack:{invited_at,joined_at},
+            harvest:{invited_at,accepted_at,seat}, deel:{status} };
+audit:[{action,by,at}]; created_at; updated_at
+```
+
+`lifecycle=active` ONLY once zoho/slack/harvest each have an activation timestamp
+("onboarded"). Phase 1 leaves all activation timestamps **null**.
+
+## The Deel-field finding (why backfill reads BOTH endpoints)
+
+The onboarding-complete gate is **not** reliably available on `/contracts`:
+
+- `/contracts.status` (`in_progress`, `completed`, `cancelled`, `user_cancelled`, …)
+  only tells you the contract is signed/active — not whether the worker finished
+  Deel onboarding (compliance/ID/tax docs) or has actually started. `/contracts`
+  also has **no `start_date`**.
+- The authoritative gate is **`/people` → `employments[].hiring_status`**
+  (`active` = complete; `onboarding` / `onboarding_overdue` = incomplete),
+  confirmed against the live API and already used by `onboarding_poll.py`.
+
+So backfill **joins** the two on `employment.id == contract.id`:
+
+| Need | Source |
+|------|--------|
+| onboarding gate, `start_date`, **structured `first_name`/`last_name`** (= email source), work_email | `/people` |
+| company-typed contract `title` (confidence cross-check + display), `external_id` | `/contracts` |
+
+A single `deel-api-key` token authenticates both endpoints.
+
+## Email + confidence rules (`naming.py`, reuses `matcher.py`)
+
+- **Email (David's confirmed rule):** `username = <first given name>.<first surname>`
+  `@thirstysprout.ai`, from Deel's **structured `first_name`/`last_name`** fields.
+  - First-name field sometimes holds two given names (e.g. `Syed Asad`) → take the
+    **first** (`syed`).
+  - Last-name field sometimes holds two LATAM surnames (e.g. `Garcia Lopez`) → keep
+    the **first/paternal** one (`garcia`), drop the maternal.
+  - Normalization (lowercase, strip accents, alnum) reuses `UserMatcher.normalize_name`.
+  - `Tazeem`/`Imran` → `tazeem.imran` · `Syed Asad`/`Ali` → `syed.ali` ·
+    `Maria Fernanda`/`Garcia Lopez` → `maria.garcia`.
+  - When Deel exposes no structured last name, falls back to splitting a single
+    full-name string (first token + first/paternal surname). Using the structured
+    fields also fixes garbage contract titles (`Untitled Contract`, `Guga` → the
+    person's real `shota.kvastiani`, `gurami.chavleshvili`).
+- **`name_confidence`** = token-set of the company-typed contract `title` vs the
+  personal-details name: subset → `high`, partial overlap → `medium`, no shared
+  tokens → `low`. A `low` result means the wrong contract is likely attached — it
+  is flagged and must never be auto-provisioned.
+
+The backfill **proposes** every email; it never creates a mailbox. The proposed
+address is surfaced for human approval (later phase) so edge cases are caught.
+
+## Lifecycle assigned by the backfill
+
+| Deel `hiring_status` | lifecycle | notes |
+|----------------------|-----------|-------|
+| `onboarding` / `onboarding_overdue` | `gated` | onboarding incomplete |
+| `active` | `needs_approval` | onboarding complete, awaiting email/seat approval |
+| anything else / no active employment | *(skipped)* | inactive, terminated, no contract |
+
+`needs_approval` is the enum-valid name for the spec's "ready" (post-gate,
+pre-provision). `upsert` only sets `lifecycle` when it is unset, so a re-run never
+regresses a human/poller advance.
+
+### `backfill_back_catalog`
+
+Most current `active` workers are **pre-existing staff**, not in-flight new hires.
+Using the `onboarding_poll.py` guard (recent start AND no work email yet), the
+backfill flags pre-existing staff with `backfill_back_catalog=true` so the later
+approval poller does not ping David about the whole company. It does not change
+`lifecycle`.
+
+## Idempotency
+
+`OnboardingStore.upsert` is transactional and safe to run repeatedly/concurrently:
+on first sight it creates the doc (account scaffold + `created_at` + audit);
+on re-run it refreshes only the identity fields that actually changed, never
+regresses `lifecycle`, and writes nothing when nothing changed (`"unchanged"`).
+
+## Manual onboarding playbook (reference for provisioning — LATER phases)
+
+Captured from a real manual onboarding (contractor "Asad Ali"). Not built yet;
+this is the spec the provisioning phase must automate. All three steps are
+idempotent-by-check in the real flow (skip if already done).
+
+**Gate confirmation.** "Onboarding" on Deel = the 5-step worker flow; the contractor
+was on 4/5 with only *document upload* left → this is exactly our `gated` lifecycle.
+Provision only once `hiring_status` flips to `active`.
+
+**Names + email.** Use Deel's **structured** `first_name`/`last_name` (personal
+details), not the free-text contract "contractor name" (which was spelled
+differently — "Asad ali" — and is unreliable; this is what `name_confidence=low`
+catches). Domain: **always `@thirstysprout.ai`** for these contractors (the other
+domain `choppingblock.ai` is not used here). Email username = `firstname.lastname`,
+first given + first surname → `syed.ali` (the manual `syedasad.ali` predated this rule).
+
+**1) Zoho (admin = billing@thirstysprout.com).** Create user:
+- First/Last name = Deel `first_name`/`last_name` (e.g. `Syed Asad` / `Ali`).
+- Username = `<local-part>@thirstysprout.ai`.
+- Password = auto-generate satisfying Zoho rules: ≥8 chars, ≥1 lower, ≥1 upper,
+  ≥1 number, ≥1 special.
+- Role = **User** (never Administrator for onboarding contractors).
+- ✅ "Send credentials via email" → the contractor's **personal email** (the one
+  used to sign the Deel contract, from Deel personal details, e.g.
+  `syed.mob25@gmail.com`).
+- ✅ "Force user to change password on first login".
+
+**2) Slack (invite to "ThirstySprout – Hire Ai Talent" workspace).**
+- Invite the contractor's **work email** (the Zoho address just created).
+- Add to channels: `#announcements`, `#thirstysprout-projects-and-off-topic-stuff`
+  (confirm full list with David).
+- **Decision:** send the invite immediately, do **not** wait for the user to log in
+  to Zoho — the invite then sits in their new inbox. (Open: how to highlight it so
+  it isn't lost.) `Copy Invite Link` gives a 30-day link as an alternative.
+
+**3) Harvest (admin = billing@thirstysprout.com, Team → Invite person).**
+- **Seat constraint:** plan seats are capped (23/23 used). Each new hire needs a
+  `+1` seat first. (Open: can automation raise the seat count via API, or must it
+  just notify David? — needs API-docs check.)
+- First/Last = Deel names; Work email = Zoho address; Employee ID = blank;
+  Type = **Contractor**; Role optional; Capacity = 40h/wk default.
+- **Default billable rate = REQUIRED** — consumed by the Invoicing automation; this
+  is the value David is asked to provide at approval time. Cost rate (what we pay,
+  = Deel `payment.rate`) optional but nice for margin.
+- Permissions = **Member** (submit/edit own timesheets only).
+- Project assignment is a separate step, often unknown at invite time → may need a
+  manual/later follow-up (create the project if it doesn't exist).
+
+**Final step (open):** where to send the onboarding guide — personal email, work
+email, or Slack. To be decided with David.
+
+### Data the store will need for provisioning (not captured in Phase 1 backfill)
+`personal_email` (Zoho credential delivery), `billable_rate` (Harvest + invoicing),
+`cost_rate`. Flagged for the approval/provisioning phase.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `firestore_store.py` | `OnboardingStore`: `get` / `upsert` / `list_by_lifecycle` / `append_audit` |
+| `naming.py` | `derive_email`, `name_confidence` (reuse `matcher.py`) |
+| `test_naming.py` | unit tests — `python test_naming.py` or `pytest` |
+| `main.py` | `backfill_onboarding` HTTP function + `run_backfill(dry_run=…)` |
+| `onboarding_poll.py`, `onboarding_digest.py` | pre-existing candidate selection + Slack digest |
+
+`deel_client.py` and `matcher.py` live in `Payroll/` (single source of truth) and
+are **copied into this dir by cloudbuild at deploy** so `--source=Onboarding`
+packages them. Locally they're imported from the sibling `Payroll/` dir.
+
+## Run locally
+
+```bash
+# Unit tests (no network)
+python test_naming.py
+
+# Dry-run backfill against live Deel — reads only, writes nothing to Firestore
+python main.py
+```
+
+`run_backfill(dry_run=True)` needs only `DEEL_API_KEY` (from `../.env`). A real run
+(`dry_run=False`) additionally needs `google-cloud-firestore` and Firestore
+credentials, so it runs in Cloud Functions, not locally.
+
+## Deploy
+
+Added as step 6 in `cloudbuild.yaml` (`backfill_onboarding`, secret `deel-api-key`)
+plus a daily `onboarding-backfill` Cloud Scheduler job (07:00 Europe/Tbilisi) that
+reconciles Firestore from Deel. Trigger a one-off preview with `?dry_run=1`.
+
+**Prereqs:** Firestore in **Native mode** enabled in the project, and the function's
+runtime service account granted `roles/datastore.user`.
+
+## Decisions (confirmed by David)
+
+- **Email username rule.** `firstname.lastname` = **first** given name + **first**
+  (paternal) surname → `syed.ali`, `maria.garcia`. This is the current
+  `naming.derive_email`. (The manual `syedasad.ali` predated this rule, superseded.)
+- **Legal name source of truth.** Always Deel's **personal-details** `first_name` /
+  `last_name`, never the free-text contract contractor name.
+- **Provisioning trigger.** Fire **only when Deel onboarding is FULLY complete**
+  (`hiring_status` == `active`) — never on contract create/sign — so we never set up
+  someone who never finishes. While incomplete (`gated`), the contractor is
+  **reminded they will not be paid** until onboarding is complete.
+- **Harvest seats.** Automation **cannot** change seat count (billing). On a new hire
+  it **notifies both the user and David** to add a paid `+1` seat. David also wants
+  **availability management**: flag empty/unused seats so we can downgrade and not pay
+  for empty seats. (So: monitor seat availability + notify; never auto-charge.)
+- **Slack default channels.** `#announcements` and
+  `#thirstysprout-projects-and-off-topic-stuff` — that's the full set for now.
+- **Onboarding-guide delivery.** Send to **both** the work email and the personal email.
+- **Billable rate + project = approval form (resolved).** Not pulled from Deel. At the
+  approval/provisioning step the human fills in a form supplying the **billable rate**
+  and the **Harvest project** the contractor should be added to. These two inputs feed
+  the Harvest invite (billable rate → invoicing) and the project assignment.
+- **Offboarding = in scope (resolved).** Build it. Triggered from the **dashboard**
+  (a click): on trigger, revoke the contractor's access to **all four contractor tools**
+  — Slack, Harvest, Deel, Zoho. Mirror of the provisioning flow, in reverse.
+
+## Still open
+
+- **`new_hiring_status`.** Deel `/people` also exposes a newer `new_hiring_status`
+  alongside `hiring_status`; we gate on the proven `hiring_status`. Confirm which Deel
+  considers canonical going forward.
+- **Offboarding revoke mechanics (per tool).** Which API/action deactivates vs deletes
+  in each of Slack / Harvest / Deel / Zoho, and whether Deel contract termination is
+  in-scope or done manually. To be scoped when the offboarding phase is built.

--- a/Onboarding/firestore_store.py
+++ b/Onboarding/firestore_store.py
@@ -1,0 +1,147 @@
+"""
+OnboardingStore — Firestore state store for onboarding/offboarding.
+
+State store = FIRESTORE (collection `onboarding`, one doc per hire, keyed by the
+Deel person_id). Chosen over the payroll SQLite-on-GCS pattern because onboarding
+is event-driven (Slack button, activation poller, Deel poll can overlap) and a
+download->modify->upload cycle would clobber concurrent writes. Firestore is
+serverless + concurrent-safe; every mutating op here runs in a transaction.
+
+Mirrors the spirit of Payroll/database.py's verification_status approval gate:
+a doc is created in a non-active lifecycle and only advances when a human/poller
+confirms — backfill never fabricates activation or regresses a doc.
+
+Public API (Phase 1):
+    get(person_id)                 -> dict | None
+    upsert(person_id, ...)         -> "created" | "updated" | "unchanged"  (idempotent)
+    list_by_lifecycle(lifecycle)   -> list[dict]
+    append_audit(person_id, ...)   -> the audit entry
+"""
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from google.cloud import firestore
+
+COLLECTION = "onboarding"
+
+# Fields that backfill derives from Deel (the source of truth) and may safely
+# refresh on every run. lifecycle/accounts/created_at/audit are NOT in here —
+# they are lifecycle state and must never be clobbered by a re-run.
+IDENTITY_FIELDS = (
+    "contract_name", "personal_name", "email", "name_confidence",
+    "start_date", "backfill_back_catalog",
+)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _empty_accounts() -> Dict:
+    """Account scaffold with all activation timestamps null (Phase 1)."""
+    return {
+        "zoho": {"created_at": None, "activated_at": None},
+        "slack": {"invited_at": None, "joined_at": None},
+        "harvest": {"invited_at": None, "accepted_at": None, "seat": None},
+        "deel": {"status": None},
+    }
+
+
+class OnboardingStore:
+    def __init__(self, collection: str = COLLECTION, client: Optional[firestore.Client] = None):
+        self.client = client or firestore.Client()
+        self.collection = collection
+
+    def _ref(self, person_id):
+        return self.client.collection(self.collection).document(str(person_id))
+
+    # ---- reads --------------------------------------------------------------
+
+    def get(self, person_id) -> Optional[Dict]:
+        snap = self._ref(person_id).get()
+        return snap.to_dict() if snap.exists else None
+
+    def list_by_lifecycle(self, lifecycle: str) -> List[Dict]:
+        query = self.client.collection(self.collection).where("lifecycle", "==", lifecycle)
+        return [snap.to_dict() for snap in query.stream()]
+
+    # ---- writes (all transactional) -----------------------------------------
+
+    def upsert(self, person_id, *, identity: Dict, initial_lifecycle: str,
+               deel_status: Optional[str] = None, audit_action: str = "backfill") -> str:
+        """
+        Idempotent upsert keyed by person_id.
+
+        - First time: creates the doc with the account scaffold (null timestamps),
+          the given initial_lifecycle, created_at, and an audit entry.
+        - Re-run: refreshes only IDENTITY_FIELDS that actually changed. lifecycle
+          is set ONLY when still unset, so a human/poller advance (e.g. ->provisioning)
+          is never regressed. If nothing changed, performs no write ("unchanged").
+
+        Safe to run repeatedly and concurrently.
+        """
+        identity = {k: v for k, v in identity.items() if k in IDENTITY_FIELDS}
+        ref = self._ref(person_id)
+        client = self.client
+
+        @firestore.transactional
+        def _txn(txn) -> str:
+            snap = ref.get(transaction=txn)
+            now = _now()
+
+            if not snap.exists:
+                accounts = _empty_accounts()
+                if deel_status is not None:
+                    accounts["deel"]["status"] = deel_status
+                doc = {
+                    "person_id": str(person_id),
+                    **identity,
+                    "lifecycle": initial_lifecycle,
+                    "accounts": accounts,
+                    "audit": [{"action": f"{audit_action}_created", "by": "system", "at": now}],
+                    "created_at": now,
+                    "updated_at": now,
+                }
+                txn.set(ref, doc)
+                return "created"
+
+            existing = snap.to_dict()
+            updates = {k: v for k, v in identity.items() if existing.get(k) != v}
+
+            # lifecycle only on first sight — never regress human/poller progress
+            if not existing.get("lifecycle"):
+                updates["lifecycle"] = initial_lifecycle
+            if deel_status is not None and (existing.get("accounts") or {}).get("deel", {}).get("status") != deel_status:
+                updates["accounts.deel.status"] = deel_status
+
+            if not updates:
+                return "unchanged"
+
+            audit = existing.get("audit", [])
+            audit.append({"action": f"{audit_action}_updated", "by": "system", "at": now})
+            updates["audit"] = audit
+            updates["updated_at"] = now
+            txn.update(ref, updates)
+            return "updated"
+
+        result = _txn(client.transaction())
+        logging.info(f"upsert {person_id}: {result}")
+        return result
+
+    def append_audit(self, person_id, action: str, by: str = "system") -> Dict:
+        """Append an audit entry transactionally. Raises KeyError if doc missing."""
+        entry = {"action": action, "by": by, "at": _now()}
+        ref = self._ref(person_id)
+
+        @firestore.transactional
+        def _txn(txn):
+            snap = ref.get(transaction=txn)
+            if not snap.exists:
+                raise KeyError(f"onboarding doc not found for person_id={person_id}")
+            audit = snap.to_dict().get("audit", [])
+            audit.append(entry)
+            txn.update(ref, {"audit": audit, "updated_at": _now()})
+
+        _txn(self.client.transaction())
+        return entry

--- a/Onboarding/main.py
+++ b/Onboarding/main.py
@@ -1,0 +1,215 @@
+"""
+Onboarding backfill — Cloud Function entry point `backfill_onboarding`.
+
+Populates the Firestore `onboarding` collection from the current Deel state so the
+store reflects reality before any of the later (out-of-scope) phases run. Safe to
+run twice: every write goes through OnboardingStore's idempotent, transactional
+upsert, which never regresses lifecycle and refreshes only changed identity fields.
+
+How the data is assembled (see README + the Deel-field finding):
+  - /people    -> the onboarding GATE (employments[].hiring_status), start_date,
+                  personal-details name, work_email.  (NOT available on /contracts)
+  - /contracts -> the company-typed `title` = the SOURCE for the derived email,
+                  plus external_id and worker.full_name.
+  Joined on  employment.id == contract.id.
+
+Out of scope this phase: provisioning, Slack approval endpoint, activation poller,
+offboarding, dashboard. Account activation timestamps stay null.
+"""
+import os
+import logging
+from datetime import datetime, timezone, timedelta
+
+from dotenv import load_dotenv
+
+# Shared modules: cloudbuild copies deel_client.py + matcher.py from Payroll/ at
+# deploy (single source of truth). Locally, fall back to the sibling package.
+try:
+    from deel_client import DeelClient
+except ImportError:
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Payroll"))
+    from deel_client import DeelClient
+
+from naming import derive_email, name_confidence
+
+load_dotenv(dotenv_path="../.env")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+DEEL_API_KEY = os.getenv("DEEL_API_KEY")
+
+# Onboarding gate (confirmed against the live People API + onboarding_poll.py):
+#   active                          -> onboarding COMPLETE   -> needs_approval
+#   onboarding / onboarding_overdue -> onboarding INCOMPLETE -> gated
+STATUS_DONE = {"active"}
+STATUS_ONBOARDING = {"onboarding", "onboarding_overdue"}
+
+# Back-catalog guard (from onboarding_poll.py): a "completed onboarding" person is
+# only a genuine in-flight new hire if they started recently AND have no work email
+# yet. Everyone else is pre-existing staff; we still record them, but flag them so
+# the later approval poller does not ping David about the whole company.
+NEW_HIRE_WINDOW_DAYS = 21
+
+
+def _current_employment(person):
+    """The person's active (non-ended) employment, or None."""
+    for emp in person.get("employments", []):
+        if not emp.get("is_ended"):
+            return emp
+    return None
+
+
+def _started_recently(start_date, days=NEW_HIRE_WINDOW_DAYS):
+    if not start_date:
+        return False
+    try:
+        start = datetime.fromisoformat(start_date.replace("Z", "+00:00")).date()
+    except (ValueError, AttributeError):
+        return False
+    return start >= (datetime.now(timezone.utc).date() - timedelta(days=days))
+
+
+def build_record(person, contracts_by_id):
+    """
+    Turn one /people record into the fields backfill upserts, or None to skip
+    (no active employment / unknown gate status).
+    """
+    emp = _current_employment(person)
+    if not emp:
+        return None
+
+    hiring_status = emp.get("hiring_status") or person.get("hiring_status")
+    contract_id = emp.get("id")
+    contract = contracts_by_id.get(contract_id, {})
+
+    # Email SOURCE = company-typed contract title; fall back through worker/emp/person.
+    contract_name = (
+        contract.get("title")
+        or (contract.get("worker") or {}).get("full_name")
+        or emp.get("name")
+        or person.get("full_name")
+        or f"{person.get('first_name', '')} {person.get('last_name', '')}".strip()
+    )
+    # Confidence cross-check uses the personal-details name.
+    personal_name = (
+        person.get("full_name")
+        or f"{person.get('first_name', '')} {person.get('last_name', '')}".strip()
+    )
+
+    # Email (David's rule): from Deel's STRUCTURED first_name/last_name — take the
+    # first given name + the first (paternal) surname. Fall back to splitting the
+    # contract name string only when structured fields are missing.
+    first_name = person.get("first_name")
+    last_name = person.get("last_name")
+    if first_name and last_name:
+        email = derive_email(first_name, last_name)
+    else:
+        email = derive_email(contract_name)
+
+    start_date = emp.get("start_date") or person.get("start_date")
+
+    # Lifecycle gate.
+    if hiring_status in STATUS_ONBOARDING:
+        lifecycle = "gated"
+    elif hiring_status in STATUS_DONE:
+        lifecycle = "needs_approval"   # spec's "ready"; enum-valid pre-provision state
+    else:
+        return None  # inactive / no_active_contracts / unknown — nothing to seed
+
+    work_email = emp.get("work_email")
+    genuine_new_hire = _started_recently(start_date) and not work_email
+    back_catalog = (lifecycle == "needs_approval") and not genuine_new_hire
+
+    return {
+        "person_id": person.get("id"),
+        "identity": {
+            "contract_name": contract_name,
+            "personal_name": personal_name,
+            "email": email,
+            "name_confidence": name_confidence(contract_name, personal_name),
+            "start_date": start_date,
+            "backfill_back_catalog": back_catalog,
+        },
+        "initial_lifecycle": lifecycle,
+        "deel_status": emp.get("contract_status") or contract.get("status"),
+    }
+
+
+def run_backfill(dry_run=False):
+    """
+    Read current Deel people+contracts and upsert a Firestore doc per active hire.
+    dry_run=True logs what would be written and touches no Firestore (used for
+    local validation without google-cloud-firestore configured).
+    """
+    if not DEEL_API_KEY:
+        raise EnvironmentError("DEEL_API_KEY is not set")
+
+    deel = DeelClient(DEEL_API_KEY)
+    people = deel.get_all_people()
+    contracts = deel.get_all_contracts(contract_type=None)  # all types
+    contracts_by_id = {c["id"]: c for c in contracts}
+    logging.info(f"Fetched {len(people)} people, {len(contracts)} contracts")
+
+    store = None
+    if not dry_run:
+        from firestore_store import OnboardingStore  # imported lazily (cloud-only dep)
+        store = OnboardingStore()
+
+    summary = {"created": 0, "updated": 0, "unchanged": 0, "skipped": 0,
+               "gated": 0, "needs_approval": 0, "back_catalog": 0, "low_confidence": 0}
+
+    for person in people:
+        record = build_record(person, contracts_by_id)
+        if record is None:
+            summary["skipped"] += 1
+            continue
+
+        summary[record["initial_lifecycle"]] += 1
+        if record["identity"]["backfill_back_catalog"]:
+            summary["back_catalog"] += 1
+        if record["identity"]["name_confidence"] == "low":
+            summary["low_confidence"] += 1
+            logging.warning(
+                f"LOW confidence for person {record['person_id']}: "
+                f"contract={record['identity']['contract_name']!r} "
+                f"personal={record['identity']['personal_name']!r} "
+                f"-> proposed {record['identity']['email']} (needs human review)"
+            )
+
+        if dry_run:
+            logging.info(
+                f"[DRY] {record['initial_lifecycle']:<14} "
+                f"{record['identity']['email']} "
+                f"({record['identity']['name_confidence']}) "
+                f"back_catalog={record['identity']['backfill_back_catalog']}"
+            )
+        else:
+            result = store.upsert(
+                record["person_id"],
+                identity=record["identity"],
+                initial_lifecycle=record["initial_lifecycle"],
+                deel_status=record["deel_status"],
+            )
+            summary[result] += 1
+
+    logging.info(f"Backfill summary: {summary}")
+    return summary
+
+
+def backfill_onboarding(request):
+    """Cloud Function HTTP entry point. ?dry_run=1 to preview without writing."""
+    logging.info("Onboarding backfill triggered.")
+    try:
+        dry_run = False
+        if request is not None and hasattr(request, "args"):
+            dry_run = request.args.get("dry_run") in ("1", "true", "yes")
+        summary = run_backfill(dry_run=dry_run)
+        return f"Backfill complete: {summary}"
+    except Exception as e:
+        logging.error(f"Error in onboarding backfill: {e}")
+        return f"Error: {str(e)}", 500
+
+
+if __name__ == "__main__":
+    # Local: dry run against live Deel, no Firestore writes.
+    run_backfill(dry_run=True)

--- a/Onboarding/naming.py
+++ b/Onboarding/naming.py
@@ -1,0 +1,132 @@
+"""
+Work-email derivation + name-confidence cross-check for onboarding.
+
+Both functions reuse Payroll/matcher.py's UserMatcher.normalize_name() (lowercase,
+strip accents, collapse whitespace) so naming behaves EXACTLY like the payroll path.
+
+EMAIL RULE (David, confirmed):  username = <first given name>.<first surname>
+    @thirstysprout.ai, derived from Deel's STRUCTURED first_name / last_name fields.
+    - first given name = the FIRST token of first_name. Deel's first-name field
+      sometimes holds two given names (e.g. "Syed Asad") -> take the first ("syed").
+    - first surname    = the FIRST token of last_name. LATAM last-name fields hold
+      two surnames (e.g. "Garcia Lopez") -> keep the paternal one ("garcia"),
+      drop the maternal one.
+    Normalization (lowercase, strip accents, alnum) reuses normalize_name.
+
+    Worked examples (covered by test_naming.py):
+        first="Tazeem"        last="Imran"        -> tazeem.imran
+        first="Syed Asad"     last="Ali"          -> syed.ali   (two given names)
+        first="Maria Fernanda" last="Garcia Lopez" -> maria.garcia (two surnames)
+
+    Structured first_name/last_name come from /people. When Deel gives no structured
+    last name we fall back to splitting a single full-name string (best effort;
+    the result is always surfaced for human approval, never auto-created).
+
+CONFIDENCE RULE (token-set of contract name vs personal-details name):
+    one a subset of the other -> high
+    partial token overlap     -> medium
+    no shared tokens          -> low   (likely the wrong contract is attached —
+                                        MUST be flagged, never auto-provisioned)
+"""
+import os
+import re
+import sys
+
+# Reuse the SAME normalizer the payroll matcher uses. At deploy time cloudbuild
+# copies matcher.py into this dir (single source of truth in Payroll/); locally
+# we fall back to importing it from the sibling Payroll/ package.
+try:
+    from matcher import UserMatcher
+except ImportError:  # local dev
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Payroll"))
+    from matcher import UserMatcher
+
+EMAIL_DOMAIN = "thirstysprout.ai"
+
+_matcher = UserMatcher()
+
+
+def _tokens(name: str):
+    """Normalized whitespace tokens of a name (accents stripped, lowercased)."""
+    if not name:
+        return []
+    return [t for t in _matcher.normalize_name(name).split() if t]
+
+
+def _alnum(token: str) -> str:
+    """Strip a token down to ascii alphanumerics (drops hyphens, apostrophes...)."""
+    return re.sub(r"[^a-z0-9]", "", token)
+
+
+def _first_token(name: str) -> str:
+    """First normalized, alnum-only token of a name field ('' if none)."""
+    for t in _tokens(name):
+        a = _alnum(t)
+        if a:
+            return a
+    return ""
+
+
+def _email_from_fullname(full_name: str, domain: str):
+    """
+    Fallback split of a single full-name string (used only when Deel gives no
+    structured last name). first + first-surname: drop middle names, and for
+    4+ tokens keep the paternal (2nd-to-last) surname, dropping the maternal one.
+    """
+    tokens = [a for a in (_alnum(t) for t in _tokens(full_name)) if a]
+    if not tokens:
+        return None
+    first = tokens[0]
+    if len(tokens) >= 4:
+        surname = tokens[-2]
+    elif len(tokens) >= 2:
+        surname = tokens[-1]
+    else:
+        surname = ""
+    local = f"{first}.{surname}" if surname else first
+    return f"{local}@{domain}"
+
+
+def derive_email(first_name: str, last_name: str = None, domain: str = EMAIL_DOMAIN):
+    """
+    Derive the proposed work email (David's rule). Preferred call passes Deel's
+    STRUCTURED fields: derive_email(first_name, last_name) -> first-given-name +
+    "." + first-surname. Both fields may hold two names; we take the first token
+    of each.
+
+    Pass a single full-name string (last_name omitted) to fall back to a
+    best-effort split of that string.
+
+    Returns the email, or None if there are no usable tokens. This only PROPOSES
+    the address — provisioning is a separate, human-approved step; we never
+    auto-create a mailbox here.
+    """
+    if last_name is None:
+        return _email_from_fullname(first_name, domain)
+
+    first = _first_token(first_name)
+    surname = _first_token(last_name)
+    local = ".".join(p for p in (first, surname) if p)
+    if not local:
+        return None
+    return f"{local}@{domain}"
+
+
+def name_confidence(contract_name: str, personal_name: str) -> str:
+    """
+    Cross-check the contract name against the personal-details name.
+
+    Returns "high" | "medium" | "low". "low" means the names share no tokens —
+    likely the wrong contract is attached to this person; it MUST be flagged and
+    never auto-provisioned.
+    """
+    a = set(_tokens(contract_name))
+    b = set(_tokens(personal_name))
+
+    if not a or not b:
+        return "low"           # can't verify -> treat as low, force human review
+    if a <= b or b <= a:
+        return "high"          # one fully contained in the other
+    if a & b:
+        return "medium"        # partial overlap
+    return "low"               # no shared tokens

--- a/Onboarding/onboarding_digest.py
+++ b/Onboarding/onboarding_digest.py
@@ -1,0 +1,124 @@
+"""
+Onboarding digest — posts the "still onboarding" list to the private #onboarding
+Slack channel so you and David have visibility in one place.
+
+Team-facing only (the channel is private). Contractor-facing nudges are handled
+separately — Deel already emails onboarding reminders natively, and overdue cases
+(like a 5-week-stale onboarding) should get a human eyeball before any "no pay"
+message goes out.
+
+Meant to run on a DAILY schedule, not every poll, to avoid noise.
+Dry-run by default; pass --post to actually send.
+"""
+import os
+import sys
+import logging
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+from onboarding_poll import fetch_all_people, select_candidates
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+SLACK_TOKEN = os.getenv("SLACK_TOKEN")
+# Prefer the channel ID (bulletproof for private channels). Falls back to the name.
+ONBOARDING_CHANNEL = os.getenv("ONBOARDING_CHANNEL", "#onboarding")
+
+
+def _days_until(start_str):
+    """Negative = started N days ago (overdue); positive = starts in N days."""
+    try:
+        start = datetime.fromisoformat(start_str.replace("Z", "+00:00")).date()
+    except (ValueError, AttributeError):
+        return None
+    return (start - datetime.now(timezone.utc).date()).days
+
+
+def _line(profile):
+    name = f"{profile['first_name']} {profile['last_name']}"
+    d = _days_until(profile["start_date"])
+    if d is None:
+        when = "start date unknown"
+    elif d > 0:
+        when = f"starts in {d}d"
+    elif d == 0:
+        when = "starts today"
+    else:
+        when = f"⚠️ OVERDUE — started {abs(d)}d ago"
+    return f"• *{name}* — {when}  _(start {profile['start_date']})_"
+
+
+def build_blocks(to_remind):
+    if not to_remind:
+        return [{"type": "section",
+                 "text": {"type": "mrkdwn", "text": "✅ Nobody is mid-onboarding right now."}}]
+    ordered = sorted(to_remind, key=lambda pr: (_days_until(pr[0]["start_date"]) or 0))
+    lines = "\n".join(_line(p) for p, _ in ordered)
+    return [
+        {"type": "header",
+         "text": {"type": "plain_text", "text": f"🚀 Onboarding in progress ({len(to_remind)})"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": lines}},
+        {"type": "context", "elements": [{"type": "mrkdwn",
+            "text": "Haven't completed Deel onboarding yet — *not* provisioned. "
+                    "Overdue ones may need a personal nudge."}]},
+    ]
+
+
+def _resolve_channel(slack, channel):
+    """Best-effort: turn a #name into a channel ID. Returns the input on failure."""
+    if not channel.startswith("#"):
+        return channel
+    target = channel.lstrip("#")
+    cursor = None
+    try:
+        while True:
+            resp = slack.conversations_list(
+                types="public_channel,private_channel", limit=200, cursor=cursor)
+            for ch in resp["channels"]:
+                if ch["name"] == target:
+                    return ch["id"]
+            cursor = resp.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+    except SlackApiError as e:
+        logging.warning(f"Couldn't list channels ({e.response['error']}); posting by name. "
+                        f"If that fails, set ONBOARDING_CHANNEL to the channel ID.")
+    return channel
+
+
+def post_digest(to_remind, channel=ONBOARDING_CHANNEL, dry_run=True):
+    if dry_run:
+        print(f"[DRY RUN] Would post to {channel}:")
+        for p, _ in to_remind:
+            print("  ", _line(p))
+        return
+
+    if not SLACK_TOKEN:
+        raise SystemExit("SLACK_TOKEN not set (.env)")
+    slack = WebClient(token=SLACK_TOKEN)
+    chan = _resolve_channel(slack, channel)
+
+    try:
+        slack.chat_postMessage(channel=chan, text="Onboarding in progress",
+                               blocks=build_blocks(to_remind))
+        logging.info(f"Posted onboarding digest to {channel}")
+    except SlackApiError as e:
+        err = e.response["error"]
+        if err in ("not_in_channel", "channel_not_found"):
+            logging.error(f"Slack '{err}': invite the bot to {channel} "
+                          f"(type '/invite @yourbot' in the channel), or use the channel ID.")
+        else:
+            logging.error(f"Slack error: {err}")
+
+
+if __name__ == "__main__":
+    people = fetch_all_people()
+    _, to_remind = select_candidates(people)
+    post_digest(to_remind, dry_run="--post" not in sys.argv)
+
+
+

--- a/Onboarding/onboarding_poll.py
+++ b/Onboarding/onboarding_poll.py
@@ -1,0 +1,153 @@
+"""
+Onboarding candidate selection — reads Deel People and decides, per person,
+whether to PROVISION (onboarding done), REMIND (still onboarding), or SKIP.
+
+Gate values confirmed empirically against the Deel People API:
+    hiring_status == "active"            -> onboarding COMPLETE   -> provision
+    hiring_status == "onboarding"        -> onboarding INCOMPLETE -> remind
+    "inactive" / "no_active_contracts"   -> skip
+
+SAFETY (back-catalog guard): many existing "active" workers have a null external_id
+because the payroll matcher never linked everyone. We must NEVER mass-provision them.
+A person is only a PROVISION candidate if they are active, have NO work email yet,
+AND started recently. (For the pilot you can also pin PILOT_CONTRACT_IDS.)
+
+This module does nothing destructive — run it directly for a dry-run summary.
+"""
+import os
+import logging
+from datetime import datetime, timedelta, timezone
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+DEEL_BASE = "https://api.letsdeel.com/rest/v2"
+TOKEN = os.getenv("DEEL_ORG_TOKEN")
+
+STATUS_DONE = {"active"}            # add "ready_to_start" here if it ever appears
+STATUS_ONBOARDING = {"onboarding"}  # incomplete states that should get reminders
+NEW_HIRE_WINDOW_DAYS = 21           # back-catalog guard
+
+# Optional hard allowlist for a supervised pilot run. Empty = no restriction.
+PILOT_CONTRACT_IDS: set[str] = set()  # e.g. {"3vw95nd"}
+
+
+def _headers():
+    if not TOKEN:
+        raise SystemExit("DEEL_ORG_TOKEN not set (.env)")
+    return {"Authorization": f"Bearer {TOKEN}", "accept": "application/json"}
+
+
+def fetch_all_people(page_size=100):
+    """Fetch every person via offset pagination. Ends when a page comes back short."""
+    people, offset = [], 0
+    while True:
+        params = {"limit": page_size, "offset": offset}
+        r = requests.get(f"{DEEL_BASE}/people", headers=_headers(), params=params)
+        r.raise_for_status()
+        rows = r.json().get("data", [])
+        people.extend(rows)
+        if len(rows) < page_size:   # short (last) page — done
+            break
+        offset += page_size
+    logging.info(f"Fetched {len(people)} people")
+    return people
+
+
+def current_employment(person):
+    """The person's active (non-ended) employment, or None. Skips old contracts."""
+    for emp in person.get("employments", []):
+        if not emp.get("is_ended"):
+            return emp
+    return None
+
+
+def _personal_email(person):
+    emails = {e.get("type"): e.get("value") for e in person.get("emails", [])}
+    return emails.get("personal") or emails.get("primary")
+
+
+def _started_recently(emp, days=NEW_HIRE_WINDOW_DAYS):
+    sd = emp.get("start_date")
+    if not sd:
+        return False
+    try:
+        start = datetime.fromisoformat(sd.replace("Z", "+00:00")).date()
+    except ValueError:
+        return False
+    today = datetime.now(timezone.utc).date()
+    return start >= (today - timedelta(days=days))  # includes future start dates
+
+
+def extract_profile(person, emp):
+    """Everything provisioning needs, from a single People record."""
+    return {
+        "person_id": person.get("id"),
+        "worker_id": person.get("worker_id"),
+        "contract_id": emp.get("id"),
+        "first_name": person.get("first_name"),
+        "last_name": person.get("last_name"),
+        "preferred_first_name": person.get("preferred_first_name"),
+        "personal_email": _personal_email(person),
+        "work_email": emp.get("work_email"),
+        "start_date": emp.get("start_date"),
+        "cost_rate": (emp.get("payment") or {}).get("rate"),   # what we PAY — NOT client billable
+        "currency": (emp.get("payment") or {}).get("currency"),
+        "job_title": emp.get("job_title"),
+        "hiring_type": emp.get("hiring_type"),
+        "hiring_status": emp.get("hiring_status"),
+    }
+
+
+def classify(person):
+    """Return (action, reason, profile) where action in {provision, remind, skip}."""
+    emp = current_employment(person)
+    if not emp:
+        return "skip", "no active employment", None
+
+    profile = extract_profile(person, emp)
+    status = emp.get("hiring_status")
+
+    if PILOT_CONTRACT_IDS and profile["contract_id"] not in PILOT_CONTRACT_IDS:
+        return "skip", "not in pilot allowlist", profile
+
+    if status in STATUS_ONBOARDING:
+        return "remind", "onboarding incomplete", profile
+
+    if status in STATUS_DONE:
+        if profile["work_email"]:
+            return "skip", "already provisioned (work email set)", profile
+        if not _started_recently(emp):
+            return "skip", "active but not a recent hire (back catalog)", profile
+        return "provision", "onboarding complete, no work email, recent start", profile
+
+    return "skip", f"status={status}", profile
+
+
+def select_candidates(people):
+    to_provision, to_remind = [], []
+    for p in people:
+        action, reason, profile = classify(p)
+        if action == "provision":
+            to_provision.append((profile, reason))
+        elif action == "remind":
+            to_remind.append((profile, reason))
+    return to_provision, to_remind
+
+
+if __name__ == "__main__":
+    people = fetch_all_people()
+    to_provision, to_remind = select_candidates(people)
+
+    print(f"\n=== TO PROVISION ({len(to_provision)}) ===")
+    for prof, why in to_provision:
+        print(f"  {prof['first_name']} {prof['last_name']} | start {prof['start_date']} | {why}")
+
+    print(f"\n=== TO REMIND ({len(to_remind)}) ===")
+    for prof, why in to_remind:
+        print(f"  {prof['first_name']} {prof['last_name']} | start {prof['start_date']} | {why}")
+
+    print("\n(dry run — nothing created, nothing sent)")

--- a/Onboarding/requirements.txt
+++ b/Onboarding/requirements.txt
@@ -1,0 +1,5 @@
+requests
+ratelimit
+python-dotenv
+rapidfuzz>=3.0.0
+google-cloud-firestore>=2.11.0Le,<2.17

--- a/Onboarding/test_naming.py
+++ b/Onboarding/test_naming.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for naming.py. Runnable two ways:
+    python test_naming.py      # plain asserts, prints a summary
+    pytest test_naming.py      # standard collection
+"""
+from naming import derive_email, name_confidence
+
+
+# ---- derive_email: David's rule on STRUCTURED first_name / last_name ---------
+
+def test_email_structured_simple():
+    assert derive_email("Tazeem", "Imran") == "tazeem.imran@thirstysprout.ai"
+
+
+def test_email_structured_two_given_names():
+    # David: first-name field holds two given names -> take the first.
+    assert derive_email("Syed Asad", "Ali") == "syed.ali@thirstysprout.ai"
+
+
+def test_email_structured_two_surnames():
+    # LATAM last-name field holds two surnames -> keep the paternal (first) one.
+    assert derive_email("Maria Fernanda", "Garcia Lopez") == "maria.garcia@thirstysprout.ai"
+
+
+def test_email_structured_strips_accents():
+    assert derive_email("José", "Peña") == "jose.pena@thirstysprout.ai"
+
+
+def test_email_structured_missing_returns_none():
+    assert derive_email("", "") is None
+    assert derive_email("   ", "  ") is None
+
+
+# ---- derive_email: single-string FALLBACK (no structured last name) ----------
+
+def test_email_fullname_fallback_two_token():
+    assert derive_email("Tazeem Imran") == "tazeem.imran@thirstysprout.ai"
+
+
+def test_email_fullname_fallback_latam():
+    # 4 tokens -> first . FIRST surname (drop middle + maternal surname)
+    assert derive_email("Maria Fernanda Garcia Lopez") == "maria.garcia@thirstysprout.ai"
+
+
+def test_email_fullname_fallback_three_token():
+    # 3-token flat strings stay ambiguous; the consistent rule yields first+last.
+    # Always surfaced for human approval (backfill never auto-creates a mailbox).
+    assert derive_email("Syed Asad Ali") == "syed.ali@thirstysprout.ai"
+
+
+def test_email_no_tokens_returns_none():
+    assert derive_email("") is None
+    assert derive_email("   ") is None
+
+
+# ---- name_confidence --------------------------------------------------------
+
+def test_confidence_high_subset():
+    # contract tokens are a subset of personal-details tokens -> high
+    assert name_confidence("Tazeem Imran", "Muhammad Tazeem Imran") == "high"
+
+
+def test_confidence_latam_first_surname():
+    # email check for the LATAM case alongside its (high) confidence
+    assert derive_email("Maria Fernanda Garcia Lopez") == "maria.garcia@thirstysprout.ai"
+    assert name_confidence("Maria Garcia", "Maria Fernanda Garcia Lopez") == "high"
+
+
+def test_confidence_medium_partial_overlap():
+    # share "tazeem" only -> medium
+    assert name_confidence("Tazeem Imran", "Tazeem Khan") == "medium"
+
+
+def test_confidence_low_no_overlap():
+    # no shared tokens -> low (wrong contract likely attached)
+    assert name_confidence("Tazeem Imran", "Carlos Mendoza") == "low"
+
+
+def test_confidence_low_missing_data():
+    assert name_confidence("", "Carlos Mendoza") == "low"
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)

--- a/Payroll/deel_client.py
+++ b/Payroll/deel_client.py
@@ -15,12 +15,15 @@ class DeelClient:
 
     @sleep_and_retry
     @limits(calls=5, period=1)  # 5 calls per second
-    def get_all_contracts(self, contract_type: str = 'pay_as_you_go_time_based') -> List[Dict]:
+    def get_all_contracts(self, contract_type: Optional[str] = 'pay_as_you_go_time_based') -> List[Dict]:
         """
         Fetch all contracts from Deel API with pagination.
 
         Args:
-            contract_type: Filter by contract type (default: pay_as_you_go_time_based)
+            contract_type: Filter by contract type (default: pay_as_you_go_time_based).
+                           Pass None to return contracts of EVERY type (used by
+                           Onboarding, where new hires may be EOR/ongoing_time_based
+                           rather than pay_as_you_go_time_based).
 
         Returns:
             List of all matching contracts
@@ -40,7 +43,7 @@ class DeelClient:
                 if 'data' in data:
                     contracts = [
                         contract for contract in data['data']
-                        if contract['type'] == contract_type
+                        if contract_type is None or contract['type'] == contract_type
                     ]
                     all_contracts.extend(contracts)
 
@@ -58,6 +61,44 @@ class DeelClient:
 
         logging.info(f"Fetched {len(all_contracts)} Deel contracts")
         return all_contracts
+
+    @sleep_and_retry
+    @limits(calls=5, period=1)
+    def get_all_people(self, page_size: int = 100) -> List[Dict]:
+        """
+        Fetch all people from the Deel People API via offset pagination.
+
+        The People API (unlike /contracts) carries the onboarding gate signal
+        (employments[].hiring_status: active | onboarding | onboarding_overdue),
+        the start_date, and the personal-details name. Onboarding joins these to
+        contracts on employment.id == contract.id.
+
+        Returns:
+            List of all people records.
+        """
+        all_people = []
+        offset = 0
+        url = f"{self.base_url}/people"
+
+        while True:
+            params = {"limit": page_size, "offset": offset}
+            try:
+                response = requests.get(url, headers=self.headers, params=params)
+                response.raise_for_status()
+                rows = response.json().get("data", [])
+                all_people.extend(rows)
+
+                if len(rows) < page_size:  # short (last) page — done
+                    break
+                offset += page_size
+            except requests.exceptions.RequestException as e:
+                logging.error(f"Error fetching Deel people: {e}")
+                if hasattr(e, 'response') and e.response is not None:
+                    logging.error(f"Response: {e.response.content}")
+                break
+
+        logging.info(f"Fetched {len(all_people)} Deel people")
+        return all_people
 
     @sleep_and_retry
     @limits(calls=5, period=1)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -108,7 +108,30 @@ steps:
           --source=Payroll \
           --timeout=300s
 
-  # 6. Create Cloud Scheduler jobs
+  # 6. Deploy Onboarding Backfill (NEW - seeds Firestore from Deel, idempotent)
+  - name: 'google/cloud-sdk:slim'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        apt-get update && apt-get install -y python3 python3-pip
+        pip3 install --upgrade pip
+        # Single source of truth: copy shared modules from Payroll into the
+        # Onboarding source dir so --source=Onboarding packages them.
+        cp Payroll/deel_client.py Payroll/matcher.py Onboarding/
+        pip3 install -r Onboarding/requirements.txt
+        DEEL_API_KEY=$(gcloud secrets versions access latest --secret="deel-api-key")
+        gcloud functions deploy backfill_onboarding \
+          --region europe-west1 \
+          --runtime python311 \
+          --trigger-http \
+          --allow-unauthenticated \
+          --set-env-vars DEEL_API_KEY=$$DEEL_API_KEY \
+          --entry-point backfill_onboarding \
+          --source=Onboarding \
+          --timeout=540s
+
+  # 7. Create Cloud Scheduler jobs
   - name: 'google/cloud-sdk:slim'
     entrypoint: 'bash'
     args:
@@ -119,6 +142,7 @@ steps:
         REMINDERS_URL=$(gcloud functions describe send_timesheet_reminders --region=europe-west1 --format='value(httpsTrigger.url)')
         INVOICING_URL=$(gcloud functions describe create_invoices_http --region=europe-west1 --format='value(httpsTrigger.url)')
         MAPPING_SYNC_URL=$(gcloud functions describe sync_user_mappings --region=europe-west1 --format='value(httpsTrigger.url)')
+        BACKFILL_URL=$(gcloud functions describe backfill_onboarding --region=europe-west1 --format='value(httpsTrigger.url)')
         
         # Schedule 1: Payroll sync - Every 1st and 16th at 9 AM
         gcloud scheduler jobs delete payroll-sync --location=europe-west1 --quiet || true
@@ -161,6 +185,17 @@ steps:
           --http-method=POST \
           --time-zone="Europe/Tbilisi" \
           --description="Sync Harvest users to Deel contracts before payroll"
+
+        # Schedule 5: Onboarding backfill - daily reconcile of Firestore from Deel
+        # (idempotent; keeps lifecycle gate + derived emails in sync as people sign)
+        gcloud scheduler jobs delete onboarding-backfill --location=europe-west1 --quiet || true
+        gcloud scheduler jobs create http onboarding-backfill \
+          --location=europe-west1 \
+          --schedule="0 7 * * *" \
+          --uri=$$BACKFILL_URL \
+          --http-method=POST \
+          --time-zone="Europe/Tbilisi" \
+          --description="Reconcile onboarding Firestore docs from Deel (idempotent)"
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## What

Phase 1 of the onboarding automation: an idempotent Deel→Firestore backfill that seeds one doc per active hire, plus the state store and name/email logic the later phases build on.

## Included

- **`naming.py`** — `derive_email` (first-given-name.first-surname `@thirstysprout.ai`, David's rule) + `name_confidence` cross-check, reusing `Payroll/matcher.py`'s normalizer. 14 unit tests (`test_naming.py`).
- **`firestore_store.py`** — `OnboardingStore`: transactional `get`/`upsert`/`list_by_lifecycle`/`append_audit`. Idempotent, keyed by Deel `person_id`, never regresses `lifecycle`.
- **`main.py`** — `run_backfill(dry_run=…)` + `backfill_onboarding` HTTP entry point. Joins Deel `/people` (onboarding gate, `start_date`, structured names) with `/contracts`.
- **`deel_client.py`** — added `get_all_people()` + all-contract-types support (backward compatible).
- **`cloudbuild.yaml`** — `backfill_onboarding` deploy step (secret `deel-api-key`, `--source=Onboarding`) + daily `onboarding-backfill` scheduler.
- **`.gitignore`** — ignore the build-copied shared modules.

## Deploy prereqs (manual)

- Firestore in **Native mode** enabled
- Function runtime SA granted **`roles/datastore.user`**
- `deel-api-key` secret present in Secret Manager

Preview a run with `?dry_run=1` (reads only, writes nothing).

## Out of scope (later phases)

Provisioning, Slack approval endpoint, activation poller, offboarding, dashboard — intentionally not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)