### PR TITLE
Fix: point OnboardingStore at named Native-mode Firestore DB

### DIFF
--- a/Onboarding/README.md
+++ b/Onboarding/README.md
@@ -191,8 +191,22 @@ Added as step 6 in `cloudbuild.yaml` (`backfill_onboarding`, secret `deel-api-ke
 plus a daily `onboarding-backfill` Cloud Scheduler job (07:00 Europe/Tbilisi) that
 reconciles Firestore from Deel. Trigger a one-off preview with `?dry_run=1`.
 
-**Prereqs:** Firestore in **Native mode** enabled in the project, and the function's
-runtime service account granted `roles/datastore.user`.
+**Prereqs (one-time, done):** the project's `(default)` database is **Datastore-mode**
+(`eur3`) and cannot serve Native reads, so onboarding uses a **separate named
+Native-mode database `onboarding`** (`europe-west1`). `OnboardingStore` connects to it
+explicitly via `firestore.Client(database="onboarding")`. The gen2 (compute) and gen1
+(appspot) runtime service accounts are granted `roles/datastore.user` (project-level,
+covers all databases).
+
+Recreate elsewhere with:
+```bash
+gcloud services enable firestore.googleapis.com
+gcloud firestore databases create --database=onboarding \
+  --location=europe-west1 --type=firestore-native
+gcloud projects add-iam-policy-binding PROJECT \
+  --member="serviceAccount:PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
+  --role="roles/datastore.user"
+```
 
 ## Decisions (confirmed by David)
 

--- a/Onboarding/firestore_store.py
+++ b/Onboarding/firestore_store.py
@@ -24,6 +24,9 @@ from typing import Dict, List, Optional
 from google.cloud import firestore
 
 COLLECTION = "onboarding"
+# Named Firestore database (NOT the project's `(default)`, which is DATASTORE_MODE
+# and cannot serve Native-mode reads/writes). Created Native in europe-west1.
+DATABASE = "onboarding"
 
 # Fields that backfill derives from Deel (the source of truth) and may safely
 # refresh on every run. lifecycle/accounts/created_at/audit are NOT in here —
@@ -49,8 +52,9 @@ def _empty_accounts() -> Dict:
 
 
 class OnboardingStore:
-    def __init__(self, collection: str = COLLECTION, client: Optional[firestore.Client] = None):
-        self.client = client or firestore.Client()
+    def __init__(self, collection: str = COLLECTION, database: str = DATABASE,
+                 client: Optional[firestore.Client] = None):
+        self.client = client or firestore.Client(database=database)
         self.collection = collection
 
     def _ref(self, person_id):

--- a/Onboarding/requirements.txt
+++ b/Onboarding/requirements.txt
@@ -2,4 +2,4 @@ requests
 ratelimit
 python-dotenv
 rapidfuzz>=3.0.0
-google-cloud-firestore>=2.11.0Le,<2.17
+google-cloud-firestore>=2.13.0,<3.0.0


### PR DESCRIPTION
Follow-up from Firestore setup. The project's `(default)` database turned out to be **DATASTORE_MODE** (`eur3`) — its mode is permanent and cannot serve Native reads/writes. Rather than disrupt it, provisioned a separate **named Native-mode database `onboarding`** (`europe-west1`) and pointed the store at it.

- `firestore_store.py`: `firestore.Client(database="onboarding")` (new `DATABASE` constant + `database=` init param).
- `requirements.txt`: bump `google-cloud-firestore` to `>=2.13.0,<3.0.0` (named-database support) and fix a corrupted specifier (`>=2.11.0Le,<2.17`).
- `README.md`: document the Datastore-mode-default gotcha + recreate commands.

Infra already applied (project `charged-sector-427921-v5`):
- `firestore.googleapis.com` enabled
- Native DB `onboarding` created in `europe-west1`
- `roles/datastore.user` granted to the gen2 (compute) and gen1 (appspot) runtime SAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)