### PR TITLE
Feat: read-only onboarding dashboard (Flask/Cloud Run, IAP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 # Onboarding: shared modules copied from Payroll at deploy (single source of truth)
 Onboarding/matcher.py
 Onboarding/deel_client.py
+
+# Dashboard: OnboardingStore copied from Onboarding at deploy (single source of truth)
+Dashboard/firestore_store.py

--- a/Dashboard/.gcloudignore
+++ b/Dashboard/.gcloudignore
@@ -1,0 +1,8 @@
+# Keep the Cloud Run source upload lean.
+.git
+.gitignore
+__pycache__/
+*.pyc
+venv/
+.env
+README.md

--- a/Dashboard/Dockerfile
+++ b/Dashboard/Dockerfile
@@ -1,0 +1,17 @@
+# Read-only onboarding dashboard — Cloud Run (Flask + gunicorn).
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# App code + templates/static, plus firestore_store.py (copied from ../Onboarding
+# at deploy time — single source of truth for the DB/collection + doc shape).
+COPY . .
+
+# Cloud Run provides $PORT. gunicorn serves the Flask `app` object in app.py.
+CMD exec gunicorn --bind :$PORT --workers 2 --threads 8 --timeout 120 app:app

--- a/Dashboard/README.md
+++ b/Dashboard/README.md
@@ -1,0 +1,70 @@
+# Onboarding Dashboard (read-only)
+
+A **private, read-only** web view of the onboarding state. It renders the roster and
+per-hire detail (identity, derived email, name confidence, lifecycle, the account
+scaffold, and the audit trail) straight from the `onboarding` Native-mode Firestore
+database that `../Onboarding` backfills.
+
+**It performs no writes and touches no Deel/secrets — it only reads Firestore.**
+Approve / offboard actions belong to later phases and are intentionally absent.
+
+## Stack
+
+- **Flask + gunicorn on Cloud Run** (consistent with the repo's existing Flask usage).
+- Reads Firestore via **`OnboardingStore`** (`firestore_store.py`, the single source of
+  truth for the DB/collection names + doc shape). At deploy it is **copied in from
+  `../Onboarding`**, mirroring how the Cloud Functions copy their shared modules; locally
+  the app falls back to importing it from the sibling `Onboarding/` dir.
+
+## Privacy — Identity-Aware Proxy (IAP)
+
+The service must sit **behind IAP** so only signed-in org users reach it; it is never
+served to `allUsers`. IAP injects the caller in `X-Goog-Authenticated-User-Email`, which
+the app shows in the header. Set **`REQUIRE_IAP=1`** in the Cloud Run env so the app
+returns `403` for any request missing that header (defence in depth — it refuses to serve
+if IAP is ever misconfigured or bypassed). `/healthz` is exempt.
+
+## Routes
+
+| Route | Purpose |
+|-------|---------|
+| `GET /` | roster; summary cards + filters (`?lifecycle=`, `?confidence=`) |
+| `GET /hire/<person_id>` | full record for one hire |
+| `GET /healthz` | Cloud Run health check (unauthenticated) |
+
+## Run locally
+
+```bash
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+# Reads the real onboarding Firestore DB via Application Default Credentials:
+export GOOGLE_CLOUD_PROJECT=charged-sector-427921-v5
+gcloud auth application-default login   # one-time, if not already done
+python app.py     # http://localhost:8080  (REQUIRE_IAP unset for local dev)
+```
+
+## Deploy (Cloud Run + IAP)
+
+```bash
+# 1. Copy the shared store in (single source of truth), then deploy from source.
+cp ../Onboarding/firestore_store.py .
+gcloud run deploy onboarding-dashboard \
+  --source . \
+  --region europe-west1 \
+  --no-allow-unauthenticated \
+  --set-env-vars REQUIRE_IAP=1 \
+  --project charged-sector-427921-v5
+
+# 2. Grant the Cloud Run runtime service account Firestore read access
+#    (roles/datastore.user — same role the backfill uses).
+# 3. Put IAP in front of the service and grant your org users
+#    roles/iap.httpsResourceAccessor. (Console: Security → Identity-Aware Proxy.)
+```
+
+The runtime service account also needs `roles/datastore.user` to read the `onboarding`
+database. Keep the service **`--no-allow-unauthenticated`**; IAP handles who gets in.
+
+## Not in this phase
+
+Approve/offboard buttons, editing, and anything that mutates state. This view exists to
+give a trustworthy picture of the onboarding pipeline before those actions are built.

--- a/Dashboard/app.py
+++ b/Dashboard/app.py
@@ -1,0 +1,126 @@
+"""
+Onboarding dashboard — a PRIVATE, read-only view of the onboarding Firestore state.
+
+Phase: read-only. Renders the roster and per-hire detail (identity, derived email,
+confidence, lifecycle, account scaffold, audit trail) straight from the `onboarding`
+Native-mode Firestore database that the backfill populates. It performs NO writes and
+exposes NO Deel/secret access — it only reads Firestore. Approve/offboard actions are
+a later phase.
+
+Privacy: intended to run on Cloud Run behind Identity-Aware Proxy (IAP). IAP injects
+the authenticated user in `X-Goog-Authenticated-User-Email`; when REQUIRE_IAP=1 the app
+refuses any request lacking it (defence in depth so it is never accidentally public).
+Locally (no IAP) leave REQUIRE_IAP unset.
+
+Reuses OnboardingStore (single source of truth for the DB/collection names + doc shape);
+firestore_store.py is copied in at deploy, mirroring the Cloud Functions build.
+"""
+import os
+import logging
+
+from flask import Flask, render_template, abort, request
+
+# Shared module: copied from ../Onboarding at deploy (single source of truth for the
+# Firestore database + collection). Locally, fall back to the sibling package.
+try:
+    from firestore_store import OnboardingStore
+except ImportError:  # local dev
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "Onboarding"))
+    from firestore_store import OnboardingStore
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+app = Flask(__name__)
+
+REQUIRE_IAP = os.getenv("REQUIRE_IAP") in ("1", "true", "yes")
+
+# Order the roster surfaces lifecycles in: things needing attention first.
+LIFECYCLE_ORDER = ["needs_approval", "gated", "provisioning", "not_signed_in",
+                   "active", "offboarding", "offboarded"]
+CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+_store = None
+
+
+def store() -> OnboardingStore:
+    """Lazily construct the store so import never touches Firestore (and tests can run)."""
+    global _store
+    if _store is None:
+        _store = OnboardingStore()
+    return _store
+
+
+def current_user() -> str:
+    """The IAP-authenticated user, if present (header form: accounts.google.com:email)."""
+    raw = request.headers.get("X-Goog-Authenticated-User-Email", "")
+    return raw.split(":")[-1] if raw else ""
+
+
+@app.before_request
+def _enforce_iap():
+    if REQUIRE_IAP and request.path != "/healthz" and not current_user():
+        abort(403, "This dashboard must be accessed through Identity-Aware Proxy.")
+
+
+def _summary(docs):
+    s = {"total": len(docs), "gated": 0, "needs_approval": 0,
+         "low_confidence": 0, "back_catalog": 0}
+    for d in docs:
+        life = d.get("lifecycle")
+        if life in s:
+            s[life] += 1
+        if d.get("name_confidence") == "low":
+            s["low_confidence"] += 1
+        if d.get("backfill_back_catalog"):
+            s["back_catalog"] += 1
+    return s
+
+
+def _sort_key(d):
+    life = d.get("lifecycle") or ""
+    life_rank = LIFECYCLE_ORDER.index(life) if life in LIFECYCLE_ORDER else len(LIFECYCLE_ORDER)
+    conf_rank = CONFIDENCE_ORDER.get(d.get("name_confidence"), 3)
+    return (life_rank, conf_rank, (d.get("email") or ""))
+
+
+@app.route("/")
+def roster():
+    docs = store().list_all()
+
+    # Optional filters via query string.
+    lifecycle = request.args.get("lifecycle") or ""
+    confidence = request.args.get("confidence") or ""
+    view = docs
+    if lifecycle:
+        view = [d for d in view if d.get("lifecycle") == lifecycle]
+    if confidence:
+        view = [d for d in view if d.get("name_confidence") == confidence]
+
+    view = sorted(view, key=_sort_key)
+    return render_template(
+        "index.html",
+        rows=view,
+        summary=_summary(docs),
+        lifecycle=lifecycle,
+        confidence=confidence,
+        user=current_user(),
+    )
+
+
+@app.route("/hire/<person_id>")
+def hire(person_id):
+    doc = store().get(person_id)
+    if not doc:
+        abort(404, f"No onboarding record for {person_id}")
+    return render_template("detail.html", doc=doc, user=current_user())
+
+
+@app.route("/healthz")
+def healthz():
+    return "ok", 200
+
+
+if __name__ == "__main__":
+    # Local dev server. On Cloud Run, gunicorn serves `app` (see Dockerfile).
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", 8080)), debug=True)

--- a/Dashboard/requirements.txt
+++ b/Dashboard/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.0,<3.0
+gunicorn>=21.0,<23.0
+google-cloud-firestore>=2.13.0,<3.0.0

--- a/Dashboard/static/style.css
+++ b/Dashboard/static/style.css
@@ -1,0 +1,86 @@
+:root {
+  --bg: #0f1115; --panel: #171a21; --panel2: #1d212b; --line: #2a2f3a;
+  --text: #e6e8ec; --muted: #8b93a1; --accent: #6ea8fe;
+  --green: #46c07a; --amber: #e0a23c; --red: #e0574b;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--text);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+.mono { font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; }
+.small { font-size: 12px; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 24px; background: var(--panel); border-bottom: 1px solid var(--line);
+}
+.brand { font-weight: 600; font-size: 16px; color: var(--text); }
+.brand span { color: var(--muted); font-weight: 400; }
+.who { display: flex; align-items: center; gap: 12px; }
+.ro-badge {
+  font-size: 11px; text-transform: uppercase; letter-spacing: .06em;
+  color: var(--amber); border: 1px solid var(--amber); border-radius: 999px; padding: 2px 8px;
+}
+.user { color: var(--muted); font-size: 13px; }
+.wrap { max-width: 1080px; margin: 0 auto; padding: 24px; }
+
+/* summary cards */
+.cards { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 20px; }
+.card {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px;
+  padding: 14px 18px; min-width: 130px; color: var(--text); transition: border-color .15s;
+}
+.card:hover { text-decoration: none; border-color: var(--accent); }
+.card.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent) inset; }
+.card.warn .num { color: var(--red); }
+.card.muted { opacity: .8; }
+.card .num { font-size: 26px; font-weight: 600; }
+.card .lbl { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+
+.filternote { color: var(--muted); margin: -6px 0 14px; }
+
+/* table */
+.grid { width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 10px; overflow: hidden; }
+.grid th, .grid td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--line); }
+.grid th { color: var(--muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+.grid tbody tr:hover { background: var(--panel2); }
+.grid tr.row-low { background: rgba(224, 87, 75, .07); }
+.empty { color: var(--muted); text-align: center; padding: 24px; }
+.view { white-space: nowrap; }
+
+/* pills */
+.pill {
+  display: inline-block; font-size: 12px; padding: 2px 9px; border-radius: 999px;
+  border: 1px solid var(--line); text-transform: lowercase;
+}
+.conf-high { color: var(--green); border-color: var(--green); }
+.conf-medium { color: var(--amber); border-color: var(--amber); }
+.conf-low { color: var(--red); border-color: var(--red); }
+.life-needs_approval { color: var(--accent); border-color: var(--accent); }
+.life-gated { color: var(--amber); border-color: var(--amber); }
+.life-active { color: var(--green); border-color: var(--green); }
+.life-offboarded, .life-offboarding { color: var(--muted); }
+.muted-pill { color: var(--muted); }
+
+/* detail */
+.crumb { margin: 0 0 12px; }
+.detail-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
+.detail-head h1 { font-size: 22px; margin: 0; }
+.detail-head .pill { margin-left: 6px; }
+.banner {
+  background: rgba(224, 87, 75, .12); border: 1px solid var(--red); color: #ffd7d2;
+  border-radius: 8px; padding: 10px 14px; margin-bottom: 18px;
+}
+.panel { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; margin-bottom: 16px; }
+.panel h2 { margin: 0 0 12px; font-size: 14px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+.kv { display: grid; grid-template-columns: 160px 1fr; gap: 6px 16px; margin: 0; }
+.kv dt { color: var(--muted); }
+.kv dd { margin: 0; }
+.accounts { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; }
+.acct { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; }
+.acct h3 { margin: 0 0 8px; font-size: 13px; text-transform: capitalize; }
+.acct .kv { grid-template-columns: 100px 1fr; }
+.ts { color: var(--muted); font-size: 12px; margin: 12px 0 0; }

--- a/Dashboard/templates/base.html
+++ b/Dashboard/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Onboarding{% endblock %} · ThirstySprout</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="{{ url_for('roster') }}">Onboarding <span>dashboard</span></a>
+    <div class="who">
+      <span class="ro-badge" title="This view is read-only">read-only</span>
+      {% if user %}<span class="user">{{ user }}</span>{% endif %}
+    </div>
+  </header>
+  <main class="wrap">
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/Dashboard/templates/detail.html
+++ b/Dashboard/templates/detail.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+{% block title %}{{ doc.email or doc.person_id }}{% endblock %}
+{% block content %}
+
+<p class="crumb"><a href="{{ url_for('roster') }}">← roster</a></p>
+
+<div class="detail-head">
+  <h1 class="mono">{{ doc.email or '—' }}</h1>
+  <div>
+    <span class="pill life-{{ doc.lifecycle }}">{{ doc.lifecycle }}</span>
+    <span class="pill conf-{{ doc.name_confidence }}">{{ doc.name_confidence }} confidence</span>
+    {% if doc.backfill_back_catalog %}<span class="pill muted-pill">back-catalog</span>{% endif %}
+  </div>
+</div>
+
+{% if doc.name_confidence == 'low' %}
+<div class="banner">
+  ⚠ Low name confidence — the contract name and personal-details name disagree, so the
+  attached Deel contract may be wrong. Verify before any provisioning.
+</div>
+{% endif %}
+
+<section class="panel">
+  <h2>Identity</h2>
+  <dl class="kv">
+    <dt>person_id</dt><dd class="mono">{{ doc.person_id }}</dd>
+    <dt>personal name</dt><dd>{{ doc.personal_name or '—' }}</dd>
+    <dt>contract name</dt><dd>{{ doc.contract_name or '—' }}</dd>
+    <dt>proposed email</dt><dd class="mono">{{ doc.email or '—' }}</dd>
+    <dt>start date</dt><dd>{{ (doc.start_date or '')[:10] or '—' }}</dd>
+  </dl>
+</section>
+
+<section class="panel">
+  <h2>Accounts</h2>
+  <div class="accounts">
+    {% for name, acct in (doc.accounts or {}).items() %}
+    <div class="acct">
+      <h3>{{ name }}</h3>
+      <dl class="kv">
+        {% for k, v in acct.items() %}
+        <dt>{{ k }}</dt><dd class="{{ 'mono' if v }}">{{ v if v is not none else '—' }}</dd>
+        {% endfor %}
+      </dl>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="panel">
+  <h2>Audit</h2>
+  <table class="grid">
+    <thead><tr><th>When</th><th>Action</th><th>By</th></tr></thead>
+    <tbody>
+    {% for a in doc.audit or [] %}
+      <tr><td class="mono small">{{ a.at }}</td><td>{{ a.action }}</td><td>{{ a.by }}</td></tr>
+    {% else %}
+      <tr><td colspan="3" class="empty">No audit entries.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <p class="ts">created {{ doc.created_at }} · updated {{ doc.updated_at }}</p>
+</section>
+
+{% endblock %}

--- a/Dashboard/templates/index.html
+++ b/Dashboard/templates/index.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Roster{% endblock %}
+{% block content %}
+
+<section class="cards">
+  <a class="card" href="{{ url_for('roster') }}">
+    <div class="num">{{ summary.total }}</div><div class="lbl">total hires</div>
+  </a>
+  <a class="card {{ 'active' if lifecycle == 'needs_approval' }}" href="{{ url_for('roster', lifecycle='needs_approval') }}">
+    <div class="num">{{ summary.needs_approval }}</div><div class="lbl">needs approval</div>
+  </a>
+  <a class="card {{ 'active' if lifecycle == 'gated' }}" href="{{ url_for('roster', lifecycle='gated') }}">
+    <div class="num">{{ summary.gated }}</div><div class="lbl">gated</div>
+  </a>
+  <a class="card warn {{ 'active' if confidence == 'low' }}" href="{{ url_for('roster', confidence='low') }}">
+    <div class="num">{{ summary.low_confidence }}</div><div class="lbl">low confidence</div>
+  </a>
+  <div class="card muted">
+    <div class="num">{{ summary.back_catalog }}</div><div class="lbl">back-catalog</div>
+  </div>
+</section>
+
+{% if lifecycle or confidence %}
+<p class="filternote">
+  Filtered{% if lifecycle %} · lifecycle=<b>{{ lifecycle }}</b>{% endif %}{% if confidence %} · confidence=<b>{{ confidence }}</b>{% endif %}
+  · <a href="{{ url_for('roster') }}">clear</a>
+</p>
+{% endif %}
+
+<table class="grid">
+  <thead>
+    <tr>
+      <th>Proposed email</th><th>Lifecycle</th><th>Confidence</th>
+      <th>Start date</th><th>Deel</th><th>Source</th><th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for d in rows %}
+    <tr class="{{ 'row-low' if d.name_confidence == 'low' }}">
+      <td class="mono">{{ d.email or '—' }}</td>
+      <td><span class="pill life-{{ d.lifecycle }}">{{ d.lifecycle }}</span></td>
+      <td><span class="pill conf-{{ d.name_confidence }}">{{ d.name_confidence }}</span></td>
+      <td>{{ (d.start_date or '')[:10] or '—' }}</td>
+      <td class="mono small">{{ (d.accounts.deel.status if d.accounts and d.accounts.deel else '') or '—' }}</td>
+      <td>{{ 'back-catalog' if d.backfill_back_catalog else 'new hire' }}</td>
+      <td><a class="view" href="{{ url_for('hire', person_id=d.person_id) }}">view →</a></td>
+    </tr>
+  {% else %}
+    <tr><td colspan="7" class="empty">No records match this filter.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/Onboarding/firestore_store.py
+++ b/Onboarding/firestore_store.py
@@ -70,6 +70,10 @@ class OnboardingStore:
         query = self.client.collection(self.collection).where("lifecycle", "==", lifecycle)
         return [snap.to_dict() for snap in query.stream()]
 
+    def list_all(self) -> List[Dict]:
+        """Every onboarding doc (used by the read-only dashboard)."""
+        return [snap.to_dict() for snap in self.client.collection(self.collection).stream()]
+
     # ---- writes (all transactional) -----------------------------------------
 
     def upsert(self, person_id, *, identity: Dict, initial_lifecycle: str,


### PR DESCRIPTION
The **read-only dashboard** phase — a private web view of the onboarding pipeline.

## What
- **Roster** (`GET /`): summary cards (total / needs-approval / gated / low-confidence / back-catalog) + clickable lifecycle/confidence filters, sorted attention-first (needs_approval → low confidence → …).
- **Detail** (`GET /hire/<person_id>`): identity, proposed email, confidence, the account scaffold (zoho/slack/harvest/deel), and the audit trail. Low-confidence hires get a "verify the attached contract" banner.
- **`GET /healthz`** for Cloud Run.

## How
- **Flask + gunicorn on Cloud Run** (matches the repo's existing Flask usage rather than adding FastAPI).
- Reads Firestore through **`OnboardingStore`** (single source of truth for DB/collection names + doc shape); `firestore_store.py` is copied in at deploy like the Cloud Functions copy their shared modules, and gitignored. Added a small `list_all()` read.
- **No writes, no Deel/secret access** — reads the `onboarding` Native DB only.

## Privacy
Runs **behind Identity-Aware Proxy**; never `allUsers`. With `REQUIRE_IAP=1` the app returns **403** for any request missing the IAP identity header (defence in depth). `/healthz` exempt.

## Validation
Flask test-client checks pass: roster/filters/detail/404/health rendering, and the IAP gate (403 without header, 200 with). Real Firestore reads already proven via the deployed backfill + REST API.

## Deploy (follow-up, needs console)
`gcloud run deploy` from `Dashboard/` (`--no-allow-unauthenticated`, `REQUIRE_IAP=1`), grant the Cloud Run SA `roles/datastore.user`, then enable IAP + grant org users `roles/iap.httpsResourceAccessor`. See `Dashboard/README.md`.

## Out of scope
Approve/offboard actions (later phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)