### PR TITLE
Fix: sync_user_mappings deploy entry-point (unblocks Cloud Build)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -105,6 +105,7 @@ steps:
           --allow-unauthenticated \
           --set-env-vars DEEL_API_KEY=$$DEEL_API_KEY,HARVEST_API_KEY=$$HARVEST_API_KEY,HARVEST_ACCOUNT_ID=$$HARVEST_ACC_ID,GCS_BUCKET_NAME=$$GCS_BUCKET,SLACK_TOKEN=$$SLACK_TOKEN \
           --entry-point mapping_sync_trigger \
+          --set-build-env-vars GOOGLE_FUNCTION_SOURCE=sync_mappings.py \
           --source=Payroll \
           --timeout=300s
 


### PR DESCRIPTION
The full Cloud Build was aborting at Step #4 (`sync_user_mappings`) with a container startup failure:

```
MissingTargetException: File /workspace/main.py is expected to contain a function
named 'mapping_sync_trigger'. Found: payroll_trigger, process_payroll, … instead
```

**Cause (pre-existing, from the "automatic mapping" commit):** the step deploys `--source=Payroll --entry-point mapping_sync_trigger`, but functions-framework loads `Payroll/main.py`, which doesn't define `mapping_sync_trigger` — it lives in `Payroll/sync_mappings.py`. The container never started, and because the build aborted here, Steps 5–7 (including the onboarding scheduler) never ran.

**Fix:** point the buildpack at the correct source file with a build env var — no code coupling, `main.py` still loads only the payroll function:
```yaml
--set-build-env-vars GOOGLE_FUNCTION_SOURCE=sync_mappings.py
```

Not related to the onboarding work (those steps run after this one). YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)