### PR TITLE
cloudbuild: --set-secrets migration + fix scheduler (timezone + OIDC)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -128,7 +128,15 @@ steps:
         INVOICING_URL=$(gcloud functions describe create_invoices_http --region=europe-west1 --format='value(httpsTrigger.url)')
         MAPPING_SYNC_URL=$(gcloud functions describe sync_user_mappings --region=europe-west1 --format='value(httpsTrigger.url)')
         BACKFILL_URL=$(gcloud functions describe backfill_onboarding --region=europe-west1 --format='value(httpsTrigger.url)')
-        
+
+        # Scheduler auth: the org policy blocks public (allUsers) functions, so every
+        # job must invoke its target with an OIDC token. Grant the scheduler SA the
+        # invoker role on each function (idempotent), then pass --oidc-* on each job.
+        SCHED_SA=164865114626-compute@developer.gserviceaccount.com
+        for FN in process_payroll_http send_timesheet_reminders create_invoices_http sync_user_mappings backfill_onboarding; do
+          gcloud functions add-iam-policy-binding $$FN --region=europe-west1 --member="serviceAccount:$$SCHED_SA" --role="roles/cloudfunctions.invoker" --quiet || true
+        done
+
         # Schedule 1: Payroll sync - Every 1st and 16th at 9 AM
         gcloud scheduler jobs delete payroll-sync --location=europe-west1 --quiet || true
         gcloud scheduler jobs create http payroll-sync \
@@ -136,7 +144,9 @@ steps:
           --schedule="0 9 1,16 * *" \
           --uri=$$PAYROLL_URL \
           --http-method=POST \
-          --time-zone="Europe/Tbilisi" \
+          --time-zone="Asia/Tbilisi" \
+          --oidc-service-account-email=$$SCHED_SA \
+          --oidc-token-audience=$$PAYROLL_URL \
           --description="Sync Harvest timesheets to Deel"
         
         # Schedule 2: Timesheet reminders - Every Friday at 10 AM
@@ -148,7 +158,9 @@ steps:
           --schedule="0 10 * * 5" \
           --uri=$$REMINDERS_URL \
           --http-method=POST \
-          --time-zone="Europe/Tbilisi" \
+          --time-zone="Asia/Tbilisi" \
+          --oidc-service-account-email=$$SCHED_SA \
+          --oidc-token-audience=$$REMINDERS_URL \
           --description="Send weekly timesheet reminders every Friday"
         
         # Schedule 3: Invoicing - 1st and 16th at 10 AM
@@ -158,7 +170,9 @@ steps:
           --schedule="0 10 1,16 * *" \
           --uri=$$INVOICING_URL \
           --http-method=POST \
-          --time-zone="Europe/Tbilisi" \
+          --time-zone="Asia/Tbilisi" \
+          --oidc-service-account-email=$$SCHED_SA \
+          --oidc-token-audience=$$INVOICING_URL \
           --description="Create invoices in Harvest"
         
         # Schedule 4: Mapping sync - 1 hour before payroll (8 AM on 1st and 16th)
@@ -168,7 +182,9 @@ steps:
           --schedule="0 8 1,16 * *" \
           --uri=$$MAPPING_SYNC_URL \
           --http-method=POST \
-          --time-zone="Europe/Tbilisi" \
+          --time-zone="Asia/Tbilisi" \
+          --oidc-service-account-email=$$SCHED_SA \
+          --oidc-token-audience=$$MAPPING_SYNC_URL \
           --description="Sync Harvest users to Deel contracts before payroll"
 
         # Schedule 5: Onboarding backfill - daily reconcile of Firestore from Deel
@@ -179,7 +195,9 @@ steps:
           --schedule="0 7 * * *" \
           --uri=$$BACKFILL_URL \
           --http-method=POST \
-          --time-zone="Europe/Tbilisi" \
+          --time-zone="Asia/Tbilisi" \
+          --oidc-service-account-email=$$SCHED_SA \
+          --oidc-token-audience=$$BACKFILL_URL \
           --description="Reconcile onboarding Firestore docs from Deel (idempotent)"
 
 options:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,13 +8,12 @@ steps:
         apt-get update && apt-get install -y python3 python3-pip
         pip3 install --upgrade pip
         pip3 install -r Announcements/requirements.txt
-        SLACK_TOKEN=$(gcloud secrets versions access latest --secret="slack-token")
         gcloud functions deploy post_message_to_slack_http \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
-          --set-env-vars SLACK_TOKEN=$$SLACK_TOKEN \
+          --set-secrets SLACK_TOKEN=slack-token:latest \
           --entry-point post_message_to_slack \
           --source=Announcements
 
@@ -27,14 +26,12 @@ steps:
         apt-get update && apt-get install -y python3 python3-pip
         pip3 install --upgrade pip
         pip3 install -r Invoicing/requirements.txt
-        HARVEST_API_KEY=$(gcloud secrets versions access latest --secret="harvest-api-key")
-        HARVEST_ACC_ID=$(gcloud secrets versions access latest --secret="harvest-acc-id")
         gcloud functions deploy create_invoices_http \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
-          --set-env-vars HARVEST_API_KEY=$$HARVEST_API_KEY,HARVEST_ACCOUNT_ID=$$HARVEST_ACC_ID \
+          --set-secrets HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest \
           --entry-point invoicing_trigger \
           --source=Invoicing
 
@@ -47,16 +44,12 @@ steps:
         apt-get update && apt-get install -y python3 python3-pip
         pip3 install --upgrade pip
         pip3 install -r Payroll/requirements.txt
-        DEEL_API_KEY=$(gcloud secrets versions access latest --secret="deel-api-key")
-        HARVEST_API_KEY=$(gcloud secrets versions access latest --secret="harvest-api-key")
-        HARVEST_ACC_ID=$(gcloud secrets versions access latest --secret="harvest-acc-id")
-        GCS_BUCKET=$(gcloud secrets versions access latest --secret="gcs-bucket-name")
         gcloud functions deploy process_payroll_http \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
-          --set-env-vars DEEL_API_KEY=$$DEEL_API_KEY,HARVEST_API_KEY=$$HARVEST_API_KEY,HARVEST_ACCOUNT_ID=$$HARVEST_ACC_ID,GCS_BUCKET_NAME=$$GCS_BUCKET \
+          --set-secrets DEEL_API_KEY=deel-api-key:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest,GCS_BUCKET_NAME=gcs-bucket-name:latest \
           --entry-point payroll_trigger \
           --source=Payroll \
           --timeout=540s
@@ -70,16 +63,13 @@ steps:
         apt-get update && apt-get install -y python3 python3-pip
         pip3 install --upgrade pip
         pip3 install -r Payroll_Reminders/requirements.txt
-        SLACK_TOKEN=$(gcloud secrets versions access latest --secret="slack-token")
-        HARVEST_API_KEY=$(gcloud secrets versions access latest --secret="harvest-api-key")
-        HARVEST_ACC_ID=$(gcloud secrets versions access latest --secret="harvest-acc-id")
         gcloud functions deploy send_timesheet_reminders \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
           --no-gen2 \
-          --set-env-vars SLACK_TOKEN=$$SLACK_TOKEN,HARVEST_API_KEY=$$HARVEST_API_KEY,HARVEST_ACCOUNT_ID=$$HARVEST_ACC_ID \
+          --set-secrets SLACK_TOKEN=slack-token:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest \
           --entry-point reminder_trigger \
           --source=Payroll_Reminders \
           --timeout=120s
@@ -93,17 +83,12 @@ steps:
         apt-get update && apt-get install -y python3 python3-pip
         pip3 install --upgrade pip
         pip3 install -r Payroll/requirements.txt
-        DEEL_API_KEY=$(gcloud secrets versions access latest --secret="deel-api-key")
-        HARVEST_API_KEY=$(gcloud secrets versions access latest --secret="harvest-api-key")
-        HARVEST_ACC_ID=$(gcloud secrets versions access latest --secret="harvest-acc-id")
-        GCS_BUCKET=$(gcloud secrets versions access latest --secret="gcs-bucket-name")
-        SLACK_TOKEN=$(gcloud secrets versions access latest --secret="slack-token")
         gcloud functions deploy sync_user_mappings \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
-          --set-env-vars DEEL_API_KEY=$$DEEL_API_KEY,HARVEST_API_KEY=$$HARVEST_API_KEY,HARVEST_ACCOUNT_ID=$$HARVEST_ACC_ID,GCS_BUCKET_NAME=$$GCS_BUCKET,SLACK_TOKEN=$$SLACK_TOKEN \
+          --set-secrets DEEL_API_KEY=deel-api-key:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest,GCS_BUCKET_NAME=gcs-bucket-name:latest,SLACK_TOKEN=slack-token:latest \
           --entry-point mapping_sync_trigger \
           --set-build-env-vars GOOGLE_FUNCTION_SOURCE=sync_mappings.py \
           --source=Payroll \
@@ -121,13 +106,12 @@ steps:
         # Onboarding source dir so --source=Onboarding packages them.
         cp Payroll/deel_client.py Payroll/matcher.py Onboarding/
         pip3 install -r Onboarding/requirements.txt
-        DEEL_API_KEY=$(gcloud secrets versions access latest --secret="deel-api-key")
         gcloud functions deploy backfill_onboarding \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
-          --set-env-vars DEEL_API_KEY=$$DEEL_API_KEY \
+          --set-secrets DEEL_API_KEY=deel-api-key:latest \
           --entry-point backfill_onboarding \
           --source=Onboarding \
           --timeout=540s


### PR DESCRIPTION
Two cloudbuild fixes that together make the full build green and stop leaking secrets. Both validated.

## 1. `--set-secrets` migration
Every deploy previously fetched each secret with `gcloud secrets versions access` and passed the plaintext value via `--set-env-vars` — which **echoed live tokens into build logs / function config** and meant **rotating a secret required redeploying every function**. All six deploys now use `--set-secrets NAME=secret:latest` (runtime mount from Secret Manager). Runtime SAs (gen2 compute + gen1 appspot) granted `roles/secretmanager.secretAccessor`.

## 2. Scheduler step (Step #6) — was failing for everyone
- **Invalid timezone:** `Europe/Tbilisi` is not a real IANA zone → *every* job create failed with `INVALID_ARGUMENT: schedule or timezone are invalid`. Fixed to `Asia/Tbilisi` on all 5 jobs. (This is why **no scheduler jobs existed at all** — payroll included.)
- **Private functions need OIDC:** the org policy blocks public (`allUsers`) functions, so unauthenticated scheduler calls would 403. Added an idempotent loop granting the scheduler SA `roles/cloudfunctions.invoker` on each function, plus `--oidc-service-account-email` / `--oidc-token-audience` on all 5 jobs.

**Verified live:** recreated `onboarding-backfill` exactly this way and force-ran it → OIDC → private function → **HTTP 200**, backfill summary logged. All functions (incl. `sync_user_mappings`) already deploy clean after the earlier entry-point fix.

After merge, a full `gcloud builds submit` should complete all 7 steps and leave every cron job scheduled + authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)