### PR TITLE
Fix: --clear-env-vars so --set-secrets migration actually applies

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,7 @@ steps:
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
+          --clear-env-vars \
           --set-secrets SLACK_TOKEN=slack-token:latest \
           --entry-point post_message_to_slack \
           --source=Announcements
@@ -31,6 +32,7 @@ steps:
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
+          --clear-env-vars \
           --set-secrets HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest \
           --entry-point invoicing_trigger \
           --source=Invoicing
@@ -49,6 +51,7 @@ steps:
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
+          --clear-env-vars \
           --set-secrets DEEL_API_KEY=deel-api-key:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest,GCS_BUCKET_NAME=gcs-bucket-name:latest \
           --entry-point payroll_trigger \
           --source=Payroll \
@@ -69,6 +72,7 @@ steps:
           --trigger-http \
           --allow-unauthenticated \
           --no-gen2 \
+          --clear-env-vars \
           --set-secrets SLACK_TOKEN=slack-token:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest \
           --entry-point reminder_trigger \
           --source=Payroll_Reminders \
@@ -88,6 +92,7 @@ steps:
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
+          --clear-env-vars \
           --set-secrets DEEL_API_KEY=deel-api-key:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest,GCS_BUCKET_NAME=gcs-bucket-name:latest,SLACK_TOKEN=slack-token:latest \
           --entry-point mapping_sync_trigger \
           --set-build-env-vars GOOGLE_FUNCTION_SOURCE=sync_mappings.py \
@@ -111,6 +116,7 @@ steps:
           --runtime python311 \
           --trigger-http \
           --allow-unauthenticated \
+          --clear-env-vars \
           --set-secrets DEEL_API_KEY=deel-api-key:latest \
           --entry-point backfill_onboarding \
           --source=Onboarding \


### PR DESCRIPTION
Follow-up to the `--set-secrets` migration. The build failed at `sync_user_mappings`:

```
Secret environment variable overlaps non secret environment variable: DEEL_API_KEY
```

**Cause:** switching a var from `--set-env-vars` to `--set-secrets` doesn't drop the existing plaintext env var of the same name. On **gen2** (Cloud Run) functions the overlap is a hard error; on **gen1** it silently kept the plaintext var, so the migration never took effect there (tokens still in config/logs).

**Fix:** add `--clear-env-vars` to all six deploys so stale plaintext vars are removed before secrets are mounted. Every runtime env var comes from Secret Manager, so nothing legitimate is cleared; the build-env `GOOGLE_FUNCTION_SOURCE` is unaffected. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)