### PR TITLE
Provisioning + approval flow (dashboard approve → Zoho/Slack/Harvest) + sync_user_mappings lockdown

### DIFF
--- a/Dashboard/README.md
+++ b/Dashboard/README.md
@@ -1,49 +1,69 @@
-# Onboarding Dashboard (read-only)
+# Onboarding Dashboard
 
-A **private, read-only** web view of the onboarding state. It renders the roster and
-per-hire detail (identity, derived email, name confidence, lifecycle, the account
-scaffold, and the audit trail) straight from the `onboarding` Native-mode Firestore
-database that `../Onboarding` backfills.
+A **private** web view of the onboarding state, plus the **approval flow**. It renders
+the roster and per-hire detail (identity, derived email, name confidence, lifecycle,
+the account scaffold, and the audit trail) straight from the `onboarding` Native-mode
+Firestore database that `../Onboarding` backfills, and lets an operator approve a hire
+for provisioning.
 
-**It performs no writes and touches no Deel/secrets — it only reads Firestore.**
-Approve / offboard actions belong to later phases and are intentionally absent.
+**The dashboard stays secret-free** — it holds no Deel/Slack/Harvest keys. Its only
+writes are the guarded approval-flow transactions in `OnboardingStore`; all tool calls
+(Zoho instructions, Slack invite, Harvest contractor + project) live in the
+`provision_onboarding` Cloud Function, which the dashboard invokes with an OIDC token
+minted for its own service account. Offboarding actions are the next phase.
 
 ## Stack
 
 - **Flask + gunicorn on Cloud Run** (consistent with the repo's existing Flask usage).
-- Reads Firestore via **`OnboardingStore`** (`firestore_store.py`, the single source of
-  truth for the DB/collection names + doc shape). At deploy it is **copied in from
-  `../Onboarding`**, mirroring how the Cloud Functions copy their shared modules; locally
-  the app falls back to importing it from the sibling `Onboarding/` dir.
+- Reads/writes Firestore via **`OnboardingStore`** (`firestore_store.py`, the single
+  source of truth for the DB/collection names + doc shape). At deploy it is **copied in
+  from `../Onboarding`**; locally the app falls back to importing it from the sibling dir.
 
-## Privacy — Identity-Aware Proxy (IAP)
+## Privacy — IAP / private Cloud Run
 
-The service must sit **behind IAP** so only signed-in org users reach it; it is never
-served to `allUsers`. IAP injects the caller in `X-Goog-Authenticated-User-Email`, which
-the app shows in the header. Set **`REQUIRE_IAP=1`** in the Cloud Run env so the app
-returns `403` for any request missing that header (defence in depth — it refuses to serve
-if IAP is ever misconfigured or bypassed). `/healthz` is exempt.
+The service is `--no-allow-unauthenticated`; until IAP is set up, view it through the
+caller's own identity:
+
+```bash
+gcloud run services proxy onboarding-dashboard --region=europe-west1 \
+  --project=charged-sector-427921-v5   # then http://localhost:8080
+```
+
+Audit identity: with IAP, the `X-Goog-Authenticated-User-Email` header; on the proxy
+path, the email claim of the caller's identity token (Cloud Run IAM verified it
+upstream). `REQUIRE_IAP=1` additionally refuses any request missing the IAP header —
+set it only once real IAP is in front (it breaks the proxy path). `/healthz` is exempt.
 
 ## Routes
 
 | Route | Purpose |
 |-------|---------|
 | `GET /` | roster; summary cards + filters (`?lifecycle=`, `?confidence=`) |
-| `GET /hire/<person_id>` | full record for one hire |
+| `GET /hire/<person_id>` | full record; approve form when `needs_approval` (never for back-catalog) |
+| `POST /hire/<id>/approve` | record billable rate / cost rate / personal email / Harvest project → `provisioning`, invoke the function |
+| `POST /hire/<id>/mark/<step>` | record a manual step (`zoho_created`, `slack_invited`, `harvest_invited`) and re-invoke |
+| `POST /hire/<id>/retry` | re-invoke provisioning for a stuck hire |
 | `GET /healthz` | Cloud Run health check (unauthenticated) |
+
+If the provisioning function is unreachable, approvals/marks are still recorded in
+Firestore and flagged in the UI — the daily `onboarding-provision-sweep` scheduler (or
+the Retry button) finishes the job.
 
 ## Run locally
 
 ```bash
 python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
-# Reads the real onboarding Firestore DB via Application Default Credentials:
 export GOOGLE_CLOUD_PROJECT=charged-sector-427921-v5
 gcloud auth application-default login   # one-time, if not already done
 python app.py     # http://localhost:8080  (REQUIRE_IAP unset for local dev)
 ```
 
-## Deploy (Cloud Run + IAP)
+Locally the provisioning call needs `PROVISION_URL` plus ADC that can mint ID tokens;
+without it the approve form still records to Firestore and shows the "will be retried"
+warning.
+
+## Deploy (Cloud Run)
 
 ```bash
 # 1. Copy the shared store in (single source of truth), then deploy from source.
@@ -52,19 +72,12 @@ gcloud run deploy onboarding-dashboard \
   --source . \
   --region europe-west1 \
   --no-allow-unauthenticated \
-  --set-env-vars REQUIRE_IAP=1 \
+  --set-env-vars PROVISION_URL=$(gcloud functions describe provision_onboarding \
+      --region=europe-west1 --format='value(url)') \
   --project charged-sector-427921-v5
 
-# 2. Grant the Cloud Run runtime service account Firestore read access
-#    (roles/datastore.user — same role the backfill uses).
-# 3. Put IAP in front of the service and grant your org users
-#    roles/iap.httpsResourceAccessor. (Console: Security → Identity-Aware Proxy.)
+# 2. Runtime SA needs roles/datastore.user (already granted) and invoker on
+#    provision_onboarding (cloudbuild step 6b grants the compute SA).
+# 3. IAP later: put IAP in front, grant users roles/iap.httpsResourceAccessor,
+#    then add --set-env-vars REQUIRE_IAP=1.
 ```
-
-The runtime service account also needs `roles/datastore.user` to read the `onboarding`
-database. Keep the service **`--no-allow-unauthenticated`**; IAP handles who gets in.
-
-## Not in this phase
-
-Approve/offboard buttons, editing, and anything that mutates state. This view exists to
-give a trustworthy picture of the onboarding pipeline before those actions are built.

--- a/Dashboard/app.py
+++ b/Dashboard/app.py
@@ -1,24 +1,37 @@
 """
-Onboarding dashboard — a PRIVATE, read-only view of the onboarding Firestore state.
+Onboarding dashboard — a PRIVATE view of the onboarding Firestore state, now with
+the approval flow.
 
-Phase: read-only. Renders the roster and per-hire detail (identity, derived email,
-confidence, lifecycle, account scaffold, audit trail) straight from the `onboarding`
-Native-mode Firestore database that the backfill populates. It performs NO writes and
-exposes NO Deel/secret access — it only reads Firestore. Approve/offboard actions are
-a later phase.
+Reads render the roster and per-hire detail straight from the `onboarding` Native
+Firestore database. Writes are limited to the approval flow and go through
+OnboardingStore's transactional guards:
 
-Privacy: intended to run on Cloud Run behind Identity-Aware Proxy (IAP). IAP injects
-the authenticated user in `X-Goog-Authenticated-User-Email`; when REQUIRE_IAP=1 the app
-refuses any request lacking it (defence in depth so it is never accidentally public).
-Locally (no IAP) leave REQUIRE_IAP unset.
+  - POST /hire/<id>/approve     approval form (billable rate, cost rate, personal
+                                email, Harvest project) -> lifecycle=provisioning,
+                                then invokes the provisioning function.
+  - POST /hire/<id>/mark/<step> record a manual step (Zoho created / Slack or
+                                Harvest invited by hand) and re-invoke provisioning.
+  - POST /hire/<id>/retry       re-invoke provisioning for a stuck hire.
 
-Reuses OnboardingStore (single source of truth for the DB/collection names + doc shape);
-firestore_store.py is copied in at deploy, mirroring the Cloud Functions build.
+The dashboard stays SECRET-FREE: it holds no Deel/Slack/Harvest keys. All tool
+calls live in the `provision_onboarding` Cloud Function (PROVISION_URL), which the
+dashboard invokes with an OIDC identity token minted for its own service account;
+the Harvest-project dropdown is proxied from that function too. If the function
+is unreachable the approval is still safely recorded in Firestore — the daily
+sweep (or the Retry button) picks it up.
+
+Privacy: intended to run on Cloud Run behind IAP (REQUIRE_IAP=1 refuses requests
+missing the IAP header). While the team is on `gcloud run services proxy`, the
+audit identity falls back to the email claim of the caller's own identity token —
+Cloud Run IAM has already verified it upstream.
 """
-import os
+import base64
+import json
 import logging
+import os
 
-from flask import Flask, render_template, abort, request
+import requests
+from flask import Flask, render_template, abort, request, redirect, url_for, flash
 
 # Shared module: copied from ../Onboarding at deploy (single source of truth for the
 # Firestore database + collection). Locally, fall back to the sibling package.
@@ -32,13 +45,23 @@ except ImportError:  # local dev
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 app = Flask(__name__)
+# Sessions are only used for flash messages; a per-instance random key is fine.
+app.secret_key = os.getenv("FLASK_SECRET_KEY") or os.urandom(32)
 
 REQUIRE_IAP = os.getenv("REQUIRE_IAP") in ("1", "true", "yes")
+PROVISION_URL = os.getenv("PROVISION_URL", "")
 
 # Order the roster surfaces lifecycles in: things needing attention first.
 LIFECYCLE_ORDER = ["needs_approval", "gated", "provisioning", "not_signed_in",
                    "active", "offboarding", "offboarded"]
 CONFIDENCE_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+# Manual steps a human may record from the detail page -> (tool, field, audit action).
+MANUAL_STEPS = {
+    "zoho_created": ("zoho", "created_at", "zoho_created_manual"),
+    "slack_invited": ("slack", "invited_at", "slack_invited_manual"),
+    "harvest_invited": ("harvest", "invited_at", "harvest_invited_manual"),
+}
 
 _store = None
 
@@ -52,9 +75,24 @@ def store() -> OnboardingStore:
 
 
 def current_user() -> str:
-    """The IAP-authenticated user, if present (header form: accounts.google.com:email)."""
+    """
+    The authenticated caller, for the audit trail. Prefer the IAP header
+    (accounts.google.com:email); fall back to the email claim of the Bearer
+    identity token that `gcloud run services proxy` forwards — Cloud Run IAM
+    already verified its signature before the request reached us.
+    """
     raw = request.headers.get("X-Goog-Authenticated-User-Email", "")
-    return raw.split(":")[-1] if raw else ""
+    if raw:
+        return raw.split(":")[-1]
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        try:
+            payload = auth.split(".")[1]
+            claims = json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
+            return claims.get("email", "")
+        except Exception:
+            pass
+    return ""
 
 
 @app.before_request
@@ -63,8 +101,49 @@ def _enforce_iap():
         abort(403, "This dashboard must be accessed through Identity-Aware Proxy.")
 
 
+# ---- provisioning function client -------------------------------------------
+
+def _id_token(audience: str) -> str:
+    """OIDC token for the provisioning function, minted from our own runtime SA."""
+    from google.oauth2 import id_token as google_id_token
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+    return google_id_token.fetch_id_token(GoogleAuthRequest(), audience)
+
+
+def call_provisioning(params=None, payload=None, timeout=60):
+    """
+    Invoke provision_onboarding. Returns (ok, data-or-error-message). Never raises:
+    the Firestore write has already happened, so a dead function must degrade to
+    'recorded, will be retried', not to a user-facing 500.
+    """
+    if not PROVISION_URL:
+        return False, "PROVISION_URL is not configured"
+    try:
+        headers = {"Authorization": f"Bearer {_id_token(PROVISION_URL)}"}
+        if payload is not None:
+            resp = requests.post(PROVISION_URL, params=params, json=payload,
+                                 headers=headers, timeout=timeout)
+        else:
+            resp = requests.get(PROVISION_URL, params=params, headers=headers, timeout=timeout)
+        body = resp.json() if resp.headers.get("Content-Type", "").startswith("application/json") else {}
+        if resp.status_code != 200:
+            return False, body.get("error", f"HTTP {resp.status_code}")
+        return True, body
+    except Exception as e:
+        logging.warning(f"provisioning function unreachable: {e}")
+        return False, str(e)
+
+
+def harvest_projects():
+    """Active Harvest projects for the approve form (proxied; [] if unreachable)."""
+    ok, data = call_provisioning(params={"list": "projects"}, timeout=30)
+    return data.get("projects", []) if ok else []
+
+
+# ---- read views ---------------------------------------------------------------
+
 def _summary(docs):
-    s = {"total": len(docs), "gated": 0, "needs_approval": 0,
+    s = {"total": len(docs), "gated": 0, "needs_approval": 0, "provisioning": 0,
          "low_confidence": 0, "back_catalog": 0}
     for d in docs:
         life = d.get("lifecycle")
@@ -113,7 +192,99 @@ def hire(person_id):
     doc = store().get(person_id)
     if not doc:
         abort(404, f"No onboarding record for {person_id}")
-    return render_template("detail.html", doc=doc, user=current_user())
+    approvable = doc.get("lifecycle") == "needs_approval" and not doc.get("backfill_back_catalog")
+    return render_template(
+        "detail.html",
+        doc=doc,
+        user=current_user(),
+        approvable=approvable,
+        projects=harvest_projects() if approvable else [],
+        manual_steps=MANUAL_STEPS,
+    )
+
+
+# ---- approval flow (writes) ----------------------------------------------------
+
+@app.route("/hire/<person_id>/approve", methods=["POST"])
+def approve(person_id):
+    form = request.form
+    errors = []
+    try:
+        billable_rate = float(form.get("billable_rate", ""))
+        if billable_rate <= 0:
+            errors.append("billable rate must be > 0")
+    except ValueError:
+        billable_rate = None
+        errors.append("billable rate is required (a number)")
+
+    cost_rate = None
+    if form.get("cost_rate", "").strip():
+        try:
+            cost_rate = float(form["cost_rate"])
+        except ValueError:
+            errors.append("cost rate must be a number")
+
+    personal_email = form.get("personal_email", "").strip()
+    if "@" not in personal_email:
+        errors.append("personal email is required (Zoho credentials are sent there)")
+
+    project_id = form.get("harvest_project_id", "").strip()
+    if not project_id:
+        errors.append("a Harvest project is required")
+
+    if errors:
+        flash("Not approved: " + "; ".join(errors), "error")
+        return redirect(url_for("hire", person_id=person_id))
+
+    by = current_user() or "unknown"
+    try:
+        store().request_provision(
+            person_id, by=by, billable_rate=billable_rate, cost_rate=cost_rate,
+            personal_email=personal_email, harvest_project_id=project_id,
+            harvest_project_name=form.get("harvest_project_name", ""),
+        )
+    except (ValueError, KeyError) as e:
+        flash(f"Not approved: {e}", "error")
+        return redirect(url_for("hire", person_id=person_id))
+
+    ok, data = call_provisioning(payload={"person_id": person_id})
+    if ok:
+        flash("Approved — provisioning started (Zoho instructions sent to the operators).", "ok")
+    else:
+        flash(f"Approved and recorded; provisioning function not reached ({data}) — "
+              "use Retry or wait for the daily sweep.", "warn")
+    return redirect(url_for("hire", person_id=person_id))
+
+
+@app.route("/hire/<person_id>/mark/<step>", methods=["POST"])
+def mark_step(person_id, step):
+    if step not in MANUAL_STEPS:
+        abort(404)
+    tool, field, action = MANUAL_STEPS[step]
+    by = current_user() or "unknown"
+    from firestore_store import _now
+    try:
+        store().record_account_event(person_id, tool, {field: _now()}, action=action, by=by)
+    except KeyError as e:
+        flash(str(e), "error")
+        return redirect(url_for("hire", person_id=person_id))
+    # A newly created Zoho user unblocks the Slack/Harvest invites — run them now.
+    ok, _data = call_provisioning(payload={"person_id": person_id})
+    flash(f"Recorded {step.replace('_', ' ')}." +
+          ("" if ok else " (Provisioning function not reached — Retry later.)"),
+          "ok" if ok else "warn")
+    return redirect(url_for("hire", person_id=person_id))
+
+
+@app.route("/hire/<person_id>/retry", methods=["POST"])
+def retry(person_id):
+    ok, data = call_provisioning(payload={"person_id": person_id})
+    if ok:
+        outcome = data.get("results", {}).get(str(person_id), {})
+        flash("Provisioning ran: " + (json.dumps(outcome) if outcome else "no pending steps."), "ok")
+    else:
+        flash(f"Provisioning function not reached: {data}", "error")
+    return redirect(url_for("hire", person_id=person_id))
 
 
 @app.route("/healthz")

--- a/Dashboard/requirements.txt
+++ b/Dashboard/requirements.txt
@@ -1,3 +1,5 @@
 Flask>=2.0,<3.0
 gunicorn>=21.0,<23.0
+requests
+google-auth>=2.0
 google-cloud-firestore>=2.13.0,<3.0.0

--- a/Dashboard/static/style.css
+++ b/Dashboard/static/style.css
@@ -84,3 +84,28 @@ a:hover { text-decoration: underline; }
 .acct h3 { margin: 0 0 8px; font-size: 13px; text-transform: capitalize; }
 .acct .kv { grid-template-columns: 100px 1fr; }
 .ts { color: var(--muted); font-size: 12px; margin: 12px 0 0; }
+
+/* flash messages */
+.flash { border-radius: 8px; padding: 10px 14px; margin-bottom: 14px; border: 1px solid var(--line); }
+.flash-ok { background: rgba(70, 192, 122, .12); border-color: var(--green); color: #ccf2dc; }
+.flash-warn { background: rgba(224, 162, 60, .12); border-color: var(--amber); color: #f4e0bd; }
+.flash-error { background: rgba(224, 87, 75, .12); border-color: var(--red); color: #ffd7d2; }
+
+/* approve form + action buttons */
+.hint { color: var(--muted); margin: 0 0 14px; }
+.form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 14px; align-items: end; }
+.form-grid label { display: flex; flex-direction: column; gap: 6px; color: var(--muted); font-size: 12px; }
+.form-grid input, .form-grid select {
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
+  color: var(--text); padding: 8px 10px; font: inherit;
+}
+.form-grid input:focus, .form-grid select:focus { outline: none; border-color: var(--accent); }
+.btn {
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 6px;
+  color: var(--text); padding: 8px 16px; font: inherit; cursor: pointer;
+}
+.btn:hover { border-color: var(--accent); }
+.btn.primary { background: var(--accent); border-color: var(--accent); color: #0f1115; font-weight: 600; }
+.btn.small-btn { font-size: 12px; padding: 4px 10px; margin-top: 8px; }
+.inline-form { display: inline-block; margin-top: 10px; }
+.life-provisioning, .life-not_signed_in { color: var(--amber); border-color: var(--amber); }

--- a/Dashboard/templates/base.html
+++ b/Dashboard/templates/base.html
@@ -10,11 +10,15 @@
   <header class="topbar">
     <a class="brand" href="{{ url_for('roster') }}">Onboarding <span>dashboard</span></a>
     <div class="who">
-      <span class="ro-badge" title="This view is read-only">read-only</span>
       {% if user %}<span class="user">{{ user }}</span>{% endif %}
     </div>
   </header>
   <main class="wrap">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+        <div class="flash flash-{{ category }}">{{ message }}</div>
+      {% endfor %}
+    {% endwith %}
     {% block content %}{% endblock %}
   </main>
 </body>

--- a/Dashboard/templates/detail.html
+++ b/Dashboard/templates/detail.html
@@ -31,6 +31,69 @@
   </dl>
 </section>
 
+{% if approvable %}
+<section class="panel approve">
+  <h2>Approve &amp; provision</h2>
+  <p class="hint">
+    Approving records these values and starts provisioning: Zoho instructions are DM'd to
+    the operators first; Slack + Harvest invites go out to the work email automatically
+    once “Zoho created” is marked here.
+  </p>
+  <form method="post" action="{{ url_for('approve', person_id=doc.person_id) }}" class="form-grid">
+    <label>Billable rate (USD/h, required)
+      <input type="number" name="billable_rate" step="0.01" min="1" required>
+    </label>
+    <label>Cost rate (optional, from Deel payment rate)
+      <input type="number" name="cost_rate" step="0.01" min="0">
+    </label>
+    <label>Personal email (Zoho credentials go here)
+      <input type="email" name="personal_email" required placeholder="their Deel-signup email">
+    </label>
+    <label>Harvest project
+      {% if projects %}
+      <select name="harvest_project_id" required>
+        <option value="" disabled selected>choose a project…</option>
+        {% for p in projects %}
+        <option value="{{ p.id }}">{{ p.client }} — {{ p.name }}</option>
+        {% endfor %}
+      </select>
+      {% else %}
+      <input type="text" name="harvest_project_id" required
+             placeholder="Harvest project ID (project list unavailable)">
+      {% endif %}
+    </label>
+    <button type="submit" class="btn primary"
+            onclick="return confirm('Approve {{ doc.email }} and start provisioning?')">
+      Approve &amp; provision
+    </button>
+  </form>
+</section>
+{% elif doc.lifecycle == 'needs_approval' and doc.backfill_back_catalog %}
+<section class="panel">
+  <h2>Approve &amp; provision</h2>
+  <p class="hint">Back-catalog record (pre-existing staff) — provisioning is disabled for it.</p>
+</section>
+{% endif %}
+
+{% if doc.provision_request %}
+<section class="panel">
+  <h2>Approval</h2>
+  <dl class="kv">
+    <dt>approved by</dt><dd>{{ doc.provision_request.by }}</dd>
+    <dt>approved at</dt><dd class="mono small">{{ doc.provision_request.at }}</dd>
+    <dt>billable rate</dt><dd>{{ doc.provision_request.billable_rate }}</dd>
+    <dt>cost rate</dt><dd>{{ doc.provision_request.cost_rate if doc.provision_request.cost_rate is not none else '—' }}</dd>
+    <dt>personal email</dt><dd class="mono">{{ doc.provision_request.personal_email }}</dd>
+    <dt>harvest project</dt><dd>{{ doc.provision_request.harvest_project_name or doc.provision_request.harvest_project_id }}</dd>
+  </dl>
+  {% if doc.lifecycle == 'provisioning' %}
+  <form method="post" action="{{ url_for('retry', person_id=doc.person_id) }}" class="inline-form">
+    <button type="submit" class="btn">Retry provisioning</button>
+  </form>
+  {% endif %}
+</section>
+{% endif %}
+
 <section class="panel">
   <h2>Accounts</h2>
   <div class="accounts">
@@ -42,6 +105,18 @@
         <dt>{{ k }}</dt><dd class="{{ 'mono' if v }}">{{ v if v is not none else '—' }}</dd>
         {% endfor %}
       </dl>
+      {% if doc.lifecycle in ('provisioning', 'not_signed_in') %}
+        {% for step, spec in manual_steps.items() %}
+          {% if spec[0] == name and not acct.get(spec[1]) %}
+          <form method="post" action="{{ url_for('mark_step', person_id=doc.person_id, step=step) }}" class="inline-form">
+            <button type="submit" class="btn small-btn"
+                    onclick="return confirm('Record that this was done manually?')">
+              Mark {{ step.replace('_', ' ') }}
+            </button>
+          </form>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
     </div>
     {% endfor %}
   </div>

--- a/Dashboard/templates/index.html
+++ b/Dashboard/templates/index.html
@@ -12,6 +12,9 @@
   <a class="card {{ 'active' if lifecycle == 'gated' }}" href="{{ url_for('roster', lifecycle='gated') }}">
     <div class="num">{{ summary.gated }}</div><div class="lbl">gated</div>
   </a>
+  <a class="card {{ 'active' if lifecycle == 'provisioning' }}" href="{{ url_for('roster', lifecycle='provisioning') }}">
+    <div class="num">{{ summary.provisioning }}</div><div class="lbl">provisioning</div>
+  </a>
   <a class="card warn {{ 'active' if confidence == 'low' }}" href="{{ url_for('roster', confidence='low') }}">
     <div class="num">{{ summary.low_confidence }}</div><div class="lbl">low confidence</div>
   </a>

--- a/Onboarding/README.md
+++ b/Onboarding/README.md
@@ -161,10 +161,13 @@ email, or Slack. To be decided with David.
 
 | File | Purpose |
 |------|---------|
-| `firestore_store.py` | `OnboardingStore`: `get` / `upsert` / `list_by_lifecycle` / `append_audit` |
+| `firestore_store.py` | `OnboardingStore`: `get` / `upsert` / `list_by_lifecycle` / `append_audit` / `request_provision` / `record_account_event` |
 | `naming.py` | `derive_email`, `name_confidence` (reuse `matcher.py`) |
 | `test_naming.py` | unit tests — `python test_naming.py` or `pytest` |
 | `main.py` | `backfill_onboarding` HTTP function + `run_backfill(dry_run=…)` |
+| `provisioning.py` | `provision_onboarding` HTTP function — the approve flow (see below) |
+| `harvest_client.py` | minimal Harvest v2 client: invite contractor, assign project, seat-cap detection |
+| `slack_helpers.py` | workspace invite (API w/ manual fallback) + operator DMs |
 | `onboarding_poll.py`, `onboarding_digest.py` | pre-existing candidate selection + Slack digest |
 
 `deel_client.py` and `matcher.py` live in `Payroll/` (single source of truth) and
@@ -207,6 +210,37 @@ gcloud projects add-iam-policy-binding PROJECT \
   --member="serviceAccount:PROJECT_NUMBER-compute@developer.gserviceaccount.com" \
   --role="roles/datastore.user"
 ```
+
+## Provisioning (the approve flow)
+
+Built as the authenticated `provision_onboarding` Cloud Function (cloudbuild step 6b;
+secrets: `slack-token`, `harvest-api-key`, `harvest-acc-id`). It is invoked three ways:
+by the **dashboard** right after an approval or a manual "mark done" (OIDC, compute SA),
+by the **`onboarding-provision-sweep`** scheduler daily at 07:30 Asia/Tbilisi (empty
+POST = retry every doc stuck in `lifecycle=provisioning`), and manually. It also serves
+`GET ?list=projects` — the active Harvest projects for the dashboard's approval form,
+which keeps the dashboard itself secret-free.
+
+Flow per hire, in the playbook order (all steps idempotent, everything audit-logged):
+
+1. **Approve** (dashboard form → `request_provision`): billable rate, optional cost
+   rate, personal email, Harvest project. Guards: only `needs_approval`, never
+   back-catalog. Doc moves to `provisioning`.
+2. **Zoho — notify-a-human** (no API access yet): operators (env
+   `ONBOARDING_NOTIFY_USERS`, comma-separated Slack names) get a DM with the exact
+   playbook steps. Slack/Harvest invites **wait** here, because they target the work
+   email, which only exists once the Zoho user is created. A human then clicks
+   **Mark Zoho created** on the dashboard, which re-invokes the function.
+3. **Slack invite** to the work email: tries the admin invite API, and if the token
+   can't invite (missing scope / plan) falls back to a manual-invite DM +
+   **Mark Slack invited** on the dashboard.
+4. **Harvest**: create the contractor (Contractor, 40 h, Member, default rate = the
+   approval-form billable rate, cost rate optional) and assign to the approved project.
+   **Seat cap**: on Harvest's "no seats" 422 the operators are DMed to add a paid seat
+   (once per block — no spam) and the sweep/Retry picks the hire up after they do.
+
+When all three invites are out the store auto-advances the doc to `not_signed_in`.
+Activation to `active` stays with the (later) activation poller.
 
 ## Decisions (confirmed by David)
 

--- a/Onboarding/firestore_store.py
+++ b/Onboarding/firestore_store.py
@@ -16,6 +16,10 @@ Public API (Phase 1):
     upsert(person_id, ...)         -> "created" | "updated" | "unchanged"  (idempotent)
     list_by_lifecycle(lifecycle)   -> list[dict]
     append_audit(person_id, ...)   -> the audit entry
+
+Provisioning phase:
+    request_provision(person_id, ...)    -> the stored provision_request (dashboard approve)
+    record_account_event(person_id, ...) -> "updated" | "unchanged"  (provisioning function)
 """
 import logging
 from datetime import datetime, timezone
@@ -135,6 +139,104 @@ class OnboardingStore:
 
         result = _txn(client.transaction())
         logging.info(f"upsert {person_id}: {result}")
+        return result
+
+    def request_provision(self, person_id, *, by: str, billable_rate: float,
+                          personal_email: str, harvest_project_id,
+                          harvest_project_name: str = "",
+                          cost_rate: Optional[float] = None) -> Dict:
+        """
+        Record a human approval and advance needs_approval -> provisioning.
+
+        Stores the approval-form inputs (David's decision: billable rate + Harvest
+        project come from a human at approval time, personal email is where Zoho
+        credentials go) under `provision_request` so the provisioning function has
+        everything it needs, with `by` = the approving human for the audit trail.
+
+        Guards (raise ValueError, nothing written):
+          - doc must exist and be lifecycle == "needs_approval"
+          - back-catalog docs (pre-existing staff) are never provisionable
+        """
+        request_doc = {
+            "billable_rate": float(billable_rate),
+            "cost_rate": float(cost_rate) if cost_rate is not None else None,
+            "personal_email": personal_email,
+            "harvest_project_id": str(harvest_project_id),
+            "harvest_project_name": harvest_project_name,
+            "by": by,
+            "at": _now(),
+        }
+        ref = self._ref(person_id)
+
+        @firestore.transactional
+        def _txn(txn):
+            snap = ref.get(transaction=txn)
+            if not snap.exists:
+                raise ValueError(f"no onboarding doc for person_id={person_id}")
+            doc = snap.to_dict()
+            if doc.get("backfill_back_catalog"):
+                raise ValueError("back-catalog records cannot be provisioned")
+            if doc.get("lifecycle") != "needs_approval":
+                raise ValueError(f"lifecycle is {doc.get('lifecycle')!r}, expected 'needs_approval'")
+            audit = doc.get("audit", [])
+            audit.append({"action": "provision_requested", "by": by, "at": request_doc["at"]})
+            txn.update(ref, {
+                "lifecycle": "provisioning",
+                "provision_request": request_doc,
+                "audit": audit,
+                "updated_at": request_doc["at"],
+            })
+
+        _txn(self.client.transaction())
+        logging.info(f"request_provision {person_id}: approved by {by}")
+        return request_doc
+
+    # All three invites out -> the hire is just waiting on sign-ins.
+    _INVITE_FIELDS = (("zoho", "created_at"), ("slack", "invited_at"), ("harvest", "invited_at"))
+
+    def record_account_event(self, person_id, tool: str, fields: Dict, *,
+                             action: str, by: str = "system") -> str:
+        """
+        Set accounts.<tool>.<field> values (audit-logged, transactional). Only fields
+        whose value actually changes are written ("unchanged" if none do), so the
+        provisioning function can re-run safely.
+
+        Auto-advance: when a write completes the invite set (zoho created, slack +
+        harvest invited) while lifecycle == "provisioning", the doc moves to
+        "not_signed_in". Activation to "active" stays with the (later) poller.
+        """
+        ref = self._ref(person_id)
+
+        @firestore.transactional
+        def _txn(txn) -> str:
+            snap = ref.get(transaction=txn)
+            if not snap.exists:
+                raise KeyError(f"onboarding doc not found for person_id={person_id}")
+            doc = snap.to_dict()
+            accounts = doc.get("accounts") or {}
+            current = accounts.get(tool) or {}
+
+            updates = {f"accounts.{tool}.{k}": v for k, v in fields.items()
+                       if current.get(k) != v}
+            if not updates:
+                return "unchanged"
+
+            now = _now()
+            merged = dict(accounts)
+            merged[tool] = {**current, **fields}
+            if (doc.get("lifecycle") == "provisioning"
+                    and all((merged.get(t) or {}).get(f) for t, f in self._INVITE_FIELDS)):
+                updates["lifecycle"] = "not_signed_in"
+
+            audit = doc.get("audit", [])
+            audit.append({"action": action, "by": by, "at": now})
+            updates["audit"] = audit
+            updates["updated_at"] = now
+            txn.update(ref, updates)
+            return "updated"
+
+        result = _txn(self.client.transaction())
+        logging.info(f"record_account_event {person_id} {tool} {action}: {result}")
         return result
 
     def append_audit(self, person_id, action: str, by: str = "system") -> Dict:

--- a/Onboarding/harvest_client.py
+++ b/Onboarding/harvest_client.py
@@ -1,0 +1,106 @@
+"""
+Minimal Harvest v2 client for provisioning (invite user, assign to project).
+
+Mirrors the raw-requests style used by Payroll/Invoicing rather than pulling in a
+new dependency. Provisioning-specific concerns:
+
+  - SEAT CAP: the automation can never change the plan's seat count (billing).
+    Harvest rejects a user create with 422 when every seat is taken; that is
+    surfaced as SeatLimitError so the caller can notify humans instead of failing.
+  - Playbook defaults (David): Type=Contractor, capacity 40h/week, Member
+    permissions. Billable rate comes from the approval form (NOT Deel) and is set
+    as the user's default rate; the project assignment then uses default rates.
+"""
+import logging
+
+import requests
+
+BASE = "https://api.harvestapp.com/v2"
+FORTY_HOURS_SECONDS = 40 * 60 * 60  # weekly_capacity is expressed in seconds
+
+# 422 messages Harvest uses when the plan is out of seats.
+_SEAT_LIMIT_MARKERS = ("seat", "upgrade", "plan", "limit")
+
+
+class SeatLimitError(Exception):
+    """Every paid seat is taken — a human must add one before this hire proceeds."""
+
+
+class HarvestClient:
+    def __init__(self, api_key: str, account_id: str):
+        self.headers = {
+            "Harvest-Account-Id": str(account_id),
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": "OnboardingProvisioning",
+        }
+
+    def _get_paginated(self, path: str, key: str, params=None):
+        items, url, params = [], f"{BASE}{path}", dict(params or {})
+        while url:
+            resp = requests.get(url, headers=self.headers, params=params, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            items.extend(data[key])
+            url = data.get("links", {}).get("next")
+            params = {}
+        return items
+
+    def list_projects(self, active_only: bool = True):
+        params = {"is_active": "true"} if active_only else None
+        return self._get_paginated("/projects", "projects", params)
+
+    def list_users(self, active_only: bool = True):
+        params = {"is_active": "true"} if active_only else None
+        return self._get_paginated("/users", "users", params)
+
+    def find_user_by_email(self, email: str):
+        email = (email or "").lower()
+        for user in self.list_users(active_only=False):
+            if (user.get("email") or "").lower() == email:
+                return user
+        return None
+
+    def create_contractor(self, first_name: str, last_name: str, email: str,
+                          billable_rate: float, cost_rate=None):
+        """
+        Create (and thereby invite) a contractor. Raises SeatLimitError when the
+        plan has no free seat; re-raises anything else.
+        """
+        body = {
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "is_contractor": True,
+            "access_roles": ["member"],
+            "weekly_capacity": FORTY_HOURS_SECONDS,
+            "default_hourly_rate": float(billable_rate),
+        }
+        if cost_rate is not None:
+            body["cost_rate"] = float(cost_rate)
+
+        resp = requests.post(f"{BASE}/users", headers=self.headers, json=body, timeout=30)
+        if resp.status_code == 422:
+            message = (resp.json().get("message") or resp.text or "").lower()
+            if any(marker in message for marker in _SEAT_LIMIT_MARKERS):
+                raise SeatLimitError(message)
+        resp.raise_for_status()
+        user = resp.json()
+        logging.info(f"Harvest user created: {user.get('id')} <{email}>")
+        return user
+
+    def assign_user_to_project(self, project_id, user_id):
+        """Add the user to the project using their default (approval-form) rates."""
+        body = {"user_id": int(user_id), "use_default_rates": True}
+        resp = requests.post(f"{BASE}/projects/{project_id}/user_assignments",
+                             headers=self.headers, json=body, timeout=30)
+        if resp.status_code == 422 and "already" in (resp.text or "").lower():
+            logging.info(f"Harvest user {user_id} already assigned to project {project_id}")
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    def seat_usage(self):
+        """(active_users, note) — for flagging empty seats; Harvest exposes no
+        plan-size endpoint, so the cap itself only surfaces via the 422 on create."""
+        users = self.list_users(active_only=True)
+        return len(users), f"{len(users)} active Harvest users"

--- a/Onboarding/provisioning.py
+++ b/Onboarding/provisioning.py
@@ -1,0 +1,222 @@
+"""
+Provisioning — Cloud Function entry point `provision_onboarding`.
+
+Runs the tool-account side of an approved hire (lifecycle == "provisioning",
+`provision_request` filled in by the dashboard approve form). Deployed
+AUTHENTICATED; invoked by the dashboard (OIDC) right after an approval / manual
+mark, and by a daily scheduler sweep that retries anything still pending.
+
+Per-hire steps, in the playbook order Zoho -> Slack -> Harvest:
+
+  1. Zoho has no API access yet -> NOTIFY-A-HUMAN: DM the operators the exact
+     playbook instructions (auto-gen password, credentials to the PERSONAL email,
+     force password change). A human then creates the user and clicks
+     "mark Zoho created" in the dashboard.
+  2. Slack + Harvest invites target the WORK email, which only exists once the
+     Zoho user is created — so both steps WAIT for accounts.zoho.created_at.
+     Slack: try the admin invite API, fall back to a manual-invite DM.
+     Harvest: create the contractor (rate/cost from the approval form, 40h,
+     Member) and assign to the approved project. A full plan (seat cap) never
+     fails silently: operators are DMed to add a paid seat, and the sweep/retry
+     picks the hire up again after they do.
+
+Every step is idempotent (skipped once its accounts.* marker is set) and each
+outcome is written through OnboardingStore.record_account_event, which advances
+the doc to "not_signed_in" when all three invites are out.
+
+Also serves GET ?list=projects — the active Harvest projects for the dashboard's
+approval-form dropdown (keeps the dashboard itself secret-free).
+"""
+import json
+import logging
+import os
+
+from dotenv import load_dotenv
+from slack_sdk import WebClient
+
+from firestore_store import OnboardingStore, _now
+from harvest_client import HarvestClient, SeatLimitError
+from slack_helpers import invite_to_workspace, notify_operators
+
+load_dotenv(dotenv_path="../.env")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+HARVEST_API_KEY = os.getenv("HARVEST_API_KEY")
+HARVEST_ACCOUNT_ID = os.getenv("HARVEST_ACCOUNT_ID")
+SLACK_TOKEN = os.getenv("SLACK_TOKEN")
+
+ZOHO_INSTRUCTIONS = (
+    ":busts_in_silhouette: *Zoho user needed for {name}* (approved by {approver})\n"
+    "1. Zoho admin (`billing@thirstysprout.com`) → add user *{work_email}*, Role = *User* (never Admin)\n"
+    "2. Auto-generate the password (≥8, upper+lower+number+special)\n"
+    "3. CHECK “send credentials via email” → personal email *{personal_email}*\n"
+    "4. CHECK “force password change on first login”\n"
+    "5. Send the onboarding guide to BOTH {work_email} and {personal_email}\n"
+    "Then open the dashboard → this hire → *Mark Zoho created* (that releases the "
+    "Slack + Harvest invites, which go to the work email)."
+)
+
+SEAT_CAP_MESSAGE = (
+    ":chair: *Harvest seat cap hit* while provisioning *{name}* ({work_email}).\n"
+    "The automation cannot change seat count (billing). Please add a paid seat in "
+    "Harvest, then hit *Retry provisioning* on the dashboard (or wait for the daily sweep).\n"
+    "Harvest said: _{detail}_"
+)
+
+SLACK_MANUAL_MESSAGE = (
+    ":slack: *Manual Slack invite needed* for *{name}*: the API invite is unavailable "
+    "({detail}). Please invite *{work_email}* to the workspace with default channels "
+    "#announcements + #thirstysprout-projects-and-off-topic-stuff, then *Mark Slack "
+    "invited* on the dashboard."
+)
+
+
+def _split_name(doc):
+    """Legal name = Deel personal details (David's rule); doc stores the joined string."""
+    parts = (doc.get("personal_name") or doc.get("contract_name") or "").split()
+    if not parts:
+        return "Unknown", "Unknown"
+    return parts[0], " ".join(parts[1:]) or parts[0]
+
+
+def _acct(doc, tool):
+    return (doc.get("accounts") or {}).get(tool) or {}
+
+
+def provision_one(store: OnboardingStore, slack: WebClient, harvest: HarvestClient, doc):
+    """Run all still-pending steps for one hire. Returns a step->outcome dict."""
+    person_id = doc["person_id"]
+    req = doc.get("provision_request") or {}
+    outcomes = {}
+
+    # Hard guards — mirror the store's, in case this is invoked directly.
+    if doc.get("backfill_back_catalog"):
+        return {"skipped": "back_catalog"}
+    if doc.get("lifecycle") != "provisioning":
+        return {"skipped": f"lifecycle={doc.get('lifecycle')}"}
+    if not req:
+        return {"skipped": "no provision_request (approve via the dashboard first)"}
+
+    name = doc.get("personal_name") or doc.get("contract_name") or person_id
+    work_email = doc.get("email")
+
+    # --- 1. Zoho: notify-a-human (no API), once -------------------------------
+    if not _acct(doc, "zoho").get("created_at"):
+        if not _acct(doc, "zoho").get("requested_at"):
+            notify_operators(slack, ZOHO_INSTRUCTIONS.format(
+                name=name, approver=req.get("by", "?"), work_email=work_email,
+                personal_email=req.get("personal_email", "?")))
+            store.record_account_event(person_id, "zoho", {"requested_at": _now()},
+                                       action="zoho_manual_requested")
+            outcomes["zoho"] = "operators notified"
+        else:
+            outcomes["zoho"] = "waiting for manual creation"
+        # Work email doesn't exist until Zoho is done — hold the invites.
+        outcomes["slack"] = outcomes["harvest"] = "waiting for zoho.created_at"
+        return outcomes
+    outcomes["zoho"] = "created"
+
+    # --- 2. Slack invite (work email) ------------------------------------------
+    slack_acct = _acct(doc, "slack")
+    if slack_acct.get("invited_at"):
+        outcomes["slack"] = "already invited"
+    elif slack_acct.get("manual_requested_at"):
+        outcomes["slack"] = "waiting for manual invite"
+    else:
+        invited, detail = invite_to_workspace(slack, work_email)
+        if invited:
+            store.record_account_event(person_id, "slack",
+                                       {"invited_at": _now(), "invite_mode": "api"},
+                                       action="slack_invited")
+            outcomes["slack"] = "invited via API"
+        else:
+            notify_operators(slack, SLACK_MANUAL_MESSAGE.format(
+                name=name, work_email=work_email, detail=detail))
+            store.record_account_event(person_id, "slack",
+                                       {"manual_requested_at": _now(), "invite_mode": "manual"},
+                                       action="slack_manual_requested")
+            outcomes["slack"] = f"manual invite requested ({detail})"
+
+    # --- 3. Harvest contractor + project ---------------------------------------
+    harvest_acct = _acct(doc, "harvest")
+    if harvest_acct.get("invited_at"):
+        outcomes["harvest"] = "already invited"
+    else:
+        first, last = _split_name(doc)
+        try:
+            existing = harvest.find_user_by_email(work_email)
+            user = existing or harvest.create_contractor(
+                first, last, work_email,
+                billable_rate=req["billable_rate"], cost_rate=req.get("cost_rate"))
+            harvest.assign_user_to_project(req["harvest_project_id"], user["id"])
+            store.record_account_event(person_id, "harvest", {
+                "invited_at": _now(), "user_id": user["id"], "seat": "ok",
+                "project_id": req["harvest_project_id"],
+            }, action="harvest_invited")
+            outcomes["harvest"] = ("existing user assigned to project" if existing
+                                   else "contractor created + assigned")
+        except SeatLimitError as e:
+            if harvest_acct.get("seat") != "blocked_no_seat":  # notify once per block
+                notify_operators(slack, SEAT_CAP_MESSAGE.format(
+                    name=name, work_email=work_email, detail=str(e)[:200]))
+                store.record_account_event(person_id, "harvest", {"seat": "blocked_no_seat"},
+                                           action="harvest_seat_blocked")
+            outcomes["harvest"] = "blocked: no free seat (operators notified)"
+        except Exception as e:  # keep other hires provisionable
+            logging.error(f"Harvest provisioning failed for {person_id}: {e}")
+            outcomes["harvest"] = f"error: {e}"
+
+    return outcomes
+
+
+def run_provisioning(person_id=None):
+    """Provision one hire, or sweep everything sitting in lifecycle=provisioning."""
+    if not (HARVEST_API_KEY and HARVEST_ACCOUNT_ID and SLACK_TOKEN):
+        raise EnvironmentError("HARVEST_API_KEY / HARVEST_ACCOUNT_ID / SLACK_TOKEN not set")
+
+    store = OnboardingStore()
+    slack = WebClient(token=SLACK_TOKEN)
+    harvest = HarvestClient(HARVEST_API_KEY, HARVEST_ACCOUNT_ID)
+
+    if person_id:
+        doc = store.get(person_id)
+        if not doc:
+            raise KeyError(f"no onboarding doc for person_id={person_id}")
+        docs = [doc]
+    else:
+        docs = store.list_by_lifecycle("provisioning")
+
+    results = {}
+    for doc in docs:
+        results[doc["person_id"]] = provision_one(store, slack, harvest, doc)
+    logging.info(f"Provisioning results: {results}")
+    return results
+
+
+def provision_onboarding(request):
+    """
+    HTTP entry point (authenticated).
+      GET  ?list=projects          -> JSON active Harvest projects (dashboard dropdown)
+      POST {"person_id": "..."}    -> provision that hire now
+      POST (empty body)            -> sweep all lifecycle=provisioning docs (scheduler)
+    """
+    try:
+        if request.args.get("list") == "projects":
+            harvest = HarvestClient(HARVEST_API_KEY, HARVEST_ACCOUNT_ID)
+            projects = [{"id": p["id"], "name": p["name"],
+                         "client": (p.get("client") or {}).get("name", "")}
+                        for p in harvest.list_projects()]
+            projects.sort(key=lambda p: (p["client"], p["name"]))
+            return json.dumps({"projects": projects}), 200, {"Content-Type": "application/json"}
+
+        person_id = request.args.get("person_id")
+        if not person_id and request.is_json:
+            person_id = (request.get_json(silent=True) or {}).get("person_id")
+
+        results = run_provisioning(person_id)
+        return json.dumps({"results": results}), 200, {"Content-Type": "application/json"}
+    except (KeyError, ValueError) as e:
+        return json.dumps({"error": str(e)}), 400, {"Content-Type": "application/json"}
+    except Exception as e:
+        logging.error(f"Error in provisioning: {e}")
+        return json.dumps({"error": str(e)}), 500, {"Content-Type": "application/json"}

--- a/Onboarding/requirements.txt
+++ b/Onboarding/requirements.txt
@@ -2,4 +2,5 @@ requests
 ratelimit
 python-dotenv
 rapidfuzz>=3.0.0
+slack_sdk>=3.0
 google-cloud-firestore>=2.13.0,<3.0.0

--- a/Onboarding/slack_helpers.py
+++ b/Onboarding/slack_helpers.py
@@ -1,0 +1,94 @@
+"""
+Slack side of provisioning: workspace invites + notifying the humans.
+
+Invite reality check: programmatic workspace invites (`admin.users.invite`) only
+work with an org-admin token on paid/Grid plans. We TRY the API with whatever
+token is configured and, if Slack refuses (missing_scope / not_allowed / free
+plan), fall back to DMing the operators to send the invite by hand — provisioning
+must degrade to notify-a-human, never fail silently (David's decision).
+
+Notifications go as DMs to the operators named in ONBOARDING_NOTIFY_USERS
+(comma-separated Slack real/display names; defaults to Guga — add David's Slack
+name via the env var once confirmed). Name lookup mirrors Payroll/sync_mappings.py.
+"""
+import logging
+import os
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+# David's confirmed default-channel set for new contractors.
+DEFAULT_CHANNELS = ("announcements", "thirstysprout-projects-and-off-topic-stuff")
+
+NOTIFY_USERS = [n.strip() for n in
+                os.getenv("ONBOARDING_NOTIFY_USERS", "Guga Chavleshvili").split(",") if n.strip()]
+
+
+def _find_user_id_by_name(slack: WebClient, name: str):
+    try:
+        for member in slack.users_list()["members"]:
+            if member.get("deleted") or member.get("is_bot"):
+                continue
+            profile = member.get("profile", {})
+            if (name.lower() in profile.get("real_name", "").lower()
+                    or name.lower() in profile.get("display_name", "").lower()):
+                return member["id"]
+    except SlackApiError as e:
+        logging.error(f"Slack user lookup failed: {e.response['error']}")
+    return None
+
+
+def notify_operators(slack: WebClient, text: str) -> bool:
+    """DM every configured operator. Returns True if at least one DM went out."""
+    sent = False
+    for name in NOTIFY_USERS:
+        user_id = _find_user_id_by_name(slack, name)
+        if not user_id:
+            logging.error(f"Slack operator not found: {name!r}")
+            continue
+        try:
+            slack.chat_postMessage(channel=user_id, text=text)
+            sent = True
+        except SlackApiError as e:
+            logging.error(f"DM to {name} failed: {e.response['error']}")
+    if not sent:
+        logging.error(f"NO operator notified — message was: {text}")
+    return sent
+
+
+def _channel_ids(slack: WebClient, names):
+    wanted = {n.lstrip("#").lower() for n in names}
+    found = {}
+    cursor = None
+    try:
+        while True:
+            resp = slack.conversations_list(types="public_channel", limit=200, cursor=cursor)
+            for ch in resp["channels"]:
+                if ch["name"].lower() in wanted:
+                    found[ch["name"].lower()] = ch["id"]
+            cursor = resp.get("response_metadata", {}).get("next_cursor")
+            if not cursor or len(found) == len(wanted):
+                break
+    except SlackApiError as e:
+        logging.error(f"conversations_list failed: {e.response['error']}")
+    return list(found.values())
+
+
+def invite_to_workspace(slack: WebClient, email: str, channels=DEFAULT_CHANNELS):
+    """
+    Try the admin invite API. Returns (invited: bool, detail: str) — invited=False
+    means the caller must fall back to a manual-invite notification.
+    """
+    try:
+        team_id = slack.team_info()["team"]["id"]
+        channel_ids = _channel_ids(slack, channels)
+        if not channel_ids:
+            return False, "default channels not found via API"
+        slack.admin_users_invite(team_id=team_id, email=email,
+                                 channel_ids=",".join(channel_ids))
+        logging.info(f"Slack workspace invite sent to {email}")
+        return True, "invited via admin.users.invite"
+    except SlackApiError as e:
+        error = e.response.get("error", str(e))
+        logging.warning(f"Slack API invite unavailable for {email}: {error}")
+        return False, f"api_invite_failed:{error}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -84,20 +84,30 @@ steps:
     args:
       - '-c'
       - |
+        set -e
         apt-get update && apt-get install -y python3 python3-pip
         pip3 install --upgrade pip
         pip3 install -r Payroll/requirements.txt
+        # PRIVATE: this is a gen2 (Cloud Run) function, which the org policy does
+        # NOT block from going public — it previously had an allUsers invoker
+        # binding. Deploy authenticated and strip any leftover allUsers binding;
+        # the scheduler's compute SA gets an explicit invoker grant instead.
         gcloud functions deploy sync_user_mappings \
           --region europe-west1 \
           --runtime python311 \
           --trigger-http \
-          --allow-unauthenticated \
+          --no-allow-unauthenticated \
           --clear-env-vars \
           --set-secrets DEEL_API_KEY=deel-api-key:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest,GCS_BUCKET_NAME=gcs-bucket-name:latest,SLACK_TOKEN=slack-token:latest \
           --entry-point mapping_sync_trigger \
           --set-build-env-vars GOOGLE_FUNCTION_SOURCE=sync_mappings.py \
           --source=Payroll \
           --timeout=300s
+        gcloud functions remove-invoker-policy-binding sync_user_mappings \
+          --region=europe-west1 --member="allUsers" --quiet || true
+        gcloud functions add-invoker-policy-binding sync_user_mappings \
+          --region=europe-west1 \
+          --member="serviceAccount:164865114626-compute@developer.gserviceaccount.com" --quiet
 
   # 6. Deploy Onboarding Backfill (NEW - seeds Firestore from Deel, idempotent)
   - name: 'google/cloud-sdk:slim'
@@ -122,6 +132,34 @@ steps:
           --source=Onboarding \
           --timeout=540s
 
+  # 6b. Deploy Onboarding Provisioning (approve flow: Zoho notify, Slack invite,
+  #     Harvest contractor + project; also serves the dashboard's project list).
+  #     PRIVATE — invoked by the dashboard + scheduler sweep via OIDC (compute SA).
+  - name: 'google/cloud-sdk:slim'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -e
+        apt-get update && apt-get install -y python3 python3-pip
+        pip3 install --upgrade pip
+        pip3 install -r Onboarding/requirements.txt
+        gcloud functions deploy provision_onboarding \
+          --region europe-west1 \
+          --runtime python311 \
+          --trigger-http \
+          --no-allow-unauthenticated \
+          --clear-env-vars \
+          --set-secrets SLACK_TOKEN=slack-token:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest \
+          --entry-point provision_onboarding \
+          --set-build-env-vars GOOGLE_FUNCTION_SOURCE=provisioning.py \
+          --source=Onboarding \
+          --timeout=300s
+        # Dashboard (Cloud Run) and the scheduler both run as the compute SA.
+        gcloud functions add-invoker-policy-binding provision_onboarding \
+          --region=europe-west1 \
+          --member="serviceAccount:164865114626-compute@developer.gserviceaccount.com" --quiet
+
   # 7. Create Cloud Scheduler jobs
   - name: 'google/cloud-sdk:slim'
     entrypoint: 'bash'
@@ -145,6 +183,7 @@ steps:
         INVOICING_URL=$(geturl create_invoices_http)
         MAPPING_SYNC_URL=$(geturl sync_user_mappings)
         BACKFILL_URL=$(geturl backfill_onboarding)
+        PROVISION_URL=$(geturl provision_onboarding)
 
         # Scheduler auth: the org policy blocks public (allUsers) functions, so every
         # job must invoke its target with an OIDC token. Grant the scheduler SA the
@@ -216,6 +255,20 @@ steps:
           --oidc-service-account-email=$$SCHED_SA \
           --oidc-token-audience=$$BACKFILL_URL \
           --description="Reconcile onboarding Firestore docs from Deel (idempotent)"
+
+        # Schedule 6: Provisioning sweep - retries hires stuck in lifecycle=provisioning
+        # (e.g. seat cap was hit, Zoho was marked done but the invite call failed).
+        # POST with no person_id = sweep everything pending; every step is idempotent.
+        gcloud scheduler jobs delete onboarding-provision-sweep --location=europe-west1 --quiet || true
+        gcloud scheduler jobs create http onboarding-provision-sweep \
+          --location=europe-west1 \
+          --schedule="30 7 * * *" \
+          --uri=$$PROVISION_URL \
+          --http-method=POST \
+          --time-zone="Asia/Tbilisi" \
+          --oidc-service-account-email=$$SCHED_SA \
+          --oidc-token-audience=$$PROVISION_URL \
+          --description="Retry pending onboarding provisioning steps (idempotent sweep)"
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## What this builds

The provisioning phase of the onboarding automation, per David's confirmed decisions, plus the pending security fix.

### 1. Dashboard approval flow (`Dashboard/`)
- **Approve & provision form** on the hire detail page (only for `needs_approval`, never for back-catalog): billable rate (required), cost rate (optional), personal email (Zoho credentials go there), Harvest project (dropdown served by the provisioning function — the dashboard stays **secret-free**).
- **Manual mark-done buttons** (Zoho created / Slack invited / Harvest invited) and a **Retry provisioning** button; every action is audit-logged with the operator's identity (IAP header, or the proxy caller's identity-token email).
- If the provisioning function is unreachable, the approval is still recorded in Firestore and retried by the daily sweep.

### 2. `provision_onboarding` Cloud Function (`Onboarding/provisioning.py`)
Private (OIDC: dashboard + scheduler as compute SA). Idempotent per-step, playbook order:
1. **Zoho = notify-a-human** (no admin API yet): operators get a DM with the exact playbook steps. Slack/Harvest invites **wait for “Zoho created”** because they target the work email, which doesn't exist until then.
2. **Slack invite** via admin API when the token allows it, otherwise a manual-invite DM fallback.
3. **Harvest**: contractor created with the approval-form rates (40h, Member), assigned to the approved project. **Seat cap** → operators DMed once to add a paid seat; sweep/Retry resumes after.

When all three invites are out, the doc auto-advances to `not_signed_in` (activation poller is a later phase).

### 3. Store (`Onboarding/firestore_store.py`)
`request_provision` (transactional `needs_approval → provisioning`, refuses back-catalog) and `record_account_event` (idempotent account updates + lifecycle auto-advance).

### 4. cloudbuild
- New deploy step for `provision_onboarding` + daily `onboarding-provision-sweep` (07:30 Asia/Tbilisi).
- **`sync_user_mappings` locked down**: `--no-allow-unauthenticated`, `allUsers` invoker binding stripped, compute SA granted invoker explicitly (the scheduler keeps working).

## Verification
- All 14 existing naming tests pass.
- Dashboard: all routes exercised end-to-end with a stubbed store (roster, filters, approve happy/invalid path, back-catalog block, mark, retry, 404s, project dropdown rendering).
- Provisioning state machine: guards, Zoho gate + notify-once, idempotent re-runs, Slack API/fallback paths, Harvest create+assign, seat-cap notify-once.
- `cloudbuild.yaml` parses (8 steps).

## After merge (manual)
1. `gcloud builds submit --config=cloudbuild.yaml .` from repo root (deploys the function, sweep job, and the lockdown).
2. Redeploy the dashboard with `PROVISION_URL` (command in `Dashboard/README.md`).
3. Set `ONBOARDING_NOTIFY_USERS` on the function once David's Slack display name is confirmed (defaults to Guga only).

## Open items (next phases)
- Offboarding buttons (per-tool revoke mechanics still to be decided with David).
- IAP for browser access (you + David); activation poller → `active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)