### PR TITLE
Deploy fixes + Zoho automation (mailbox via Mail API, manual fallback)

### DIFF
--- a/Onboarding/README.md
+++ b/Onboarding/README.md
@@ -118,7 +118,7 @@ catches). Domain: **always `@thirstysprout.ai`** for these contractors (the othe
 domain `choppingblock.ai` is not used here). Email username = `firstname.lastname`,
 first given + first surname → `syed.ali` (the manual `syedasad.ali` predated this rule).
 
-**1) Zoho (admin = billing@thirstysprout.com).** Create user:
+**1) Zoho (admin = hello@thirstysprout.ai — the Zoho Mail domain admin).** Create user:
 - First/Last name = Deel `first_name`/`last_name` (e.g. `Syed Asad` / `Ali`).
 - Username = `<local-part>@thirstysprout.ai`.
 - Password = auto-generate satisfying Zoho rules: ≥8 chars, ≥1 lower, ≥1 upper,

--- a/Onboarding/README.md
+++ b/Onboarding/README.md
@@ -168,6 +168,7 @@ email, or Slack. To be decided with David.
 | `provisioning.py` | `provision_onboarding` HTTP function — the approve flow (see below) |
 | `harvest_client.py` | minimal Harvest v2 client: invite contractor, assign project, seat-cap detection |
 | `slack_helpers.py` | workspace invite (API w/ manual fallback) + operator DMs |
+| `zoho_client.py` | Zoho Mail admin client: refresh-token auth, list/create org mailboxes |
 | `onboarding_poll.py`, `onboarding_digest.py` | pre-existing candidate selection + Slack digest |
 
 `deel_client.py` and `matcher.py` live in `Payroll/` (single source of truth) and
@@ -214,7 +215,8 @@ gcloud projects add-iam-policy-binding PROJECT \
 ## Provisioning (the approve flow)
 
 Built as the authenticated `provision_onboarding` Cloud Function (cloudbuild step 6b;
-secrets: `slack-token`, `harvest-api-key`, `harvest-acc-id`). It is invoked three ways:
+secrets: `slack-token`, `harvest-api-key`, `harvest-acc-id`, `zoho-client-id`,
+`zoho-client-secret`, `zoho-refresh-token`). It is invoked three ways:
 by the **dashboard** right after an approval or a manual "mark done" (OIDC, compute SA),
 by the **`onboarding-provision-sweep`** scheduler daily at 07:30 Asia/Tbilisi (empty
 POST = retry every doc stuck in `lifecycle=provisioning`), and manually. It also serves
@@ -226,11 +228,17 @@ Flow per hire, in the playbook order (all steps idempotent, everything audit-log
 1. **Approve** (dashboard form → `request_provision`): billable rate, optional cost
    rate, personal email, Harvest project. Guards: only `needs_approval`, never
    back-catalog. Doc moves to `provisioning`.
-2. **Zoho — notify-a-human** (no API access yet): operators (env
-   `ONBOARDING_NOTIFY_USERS`, comma-separated Slack names) get a DM with the exact
-   playbook steps. Slack/Harvest invites **wait** here, because they target the work
-   email, which only exists once the Zoho user is created. A human then clicks
-   **Mark Zoho created** on the dashboard, which re-invokes the function.
+2. **Zoho — API first, human fallback**: the work mailbox is created via the Zoho
+   Mail API (`zoho_client.py`; Self Client of `hello@thirstysprout.ai`, scope
+   `ZohoMail.organization.accounts.ALL`, US DC) with an auto-generated password,
+   forced change at first login, role=member. The operators (env
+   `ONBOARDING_NOTIFY_USERS`, comma-separated Slack names) get a DM with the
+   one-time password to forward to the hire's **personal** email (it is never
+   stored). On success the flow continues to Slack/Harvest in the same run.
+   If the Zoho secrets are missing or the API call fails, it degrades to the old
+   notify-a-human DM with the exact playbook steps; Slack/Harvest invites **wait**
+   (they target the work email, which only exists once the Zoho user is created)
+   until a human clicks **Mark Zoho created** on the dashboard.
 3. **Slack invite** to the work email: tries the admin invite API, and if the token
    can't invite (missing scope / plan) falls back to a manual-invite DM +
    **Mark Slack invited** on the dashboard.

--- a/Onboarding/harvest_client.py
+++ b/Onboarding/harvest_client.py
@@ -28,9 +28,11 @@ class SeatLimitError(Exception):
 
 class HarvestClient:
     def __init__(self, api_key: str, account_id: str):
+        # .strip(): header values reject the trailing newline `echo`-created
+        # secret versions carry.
         self.headers = {
-            "Harvest-Account-Id": str(account_id),
-            "Authorization": f"Bearer {api_key}",
+            "Harvest-Account-Id": str(account_id).strip(),
+            "Authorization": f"Bearer {str(api_key).strip()}",
             "User-Agent": "OnboardingProvisioning",
         }
 

--- a/Onboarding/provisioning.py
+++ b/Onboarding/provisioning.py
@@ -49,7 +49,7 @@ SLACK_TOKEN = (os.getenv("SLACK_TOKEN") or "").strip()
 
 ZOHO_INSTRUCTIONS = (
     ":busts_in_silhouette: *Zoho user needed for {name}* (approved by {approver})\n"
-    "1. Zoho admin (`billing@thirstysprout.com`) → add user *{work_email}*, Role = *User* (never Admin)\n"
+    "1. Zoho admin (`hello@thirstysprout.ai`) → add user *{work_email}*, Role = *User* (never Admin)\n"
     "2. Auto-generate the password (≥8, upper+lower+number+special)\n"
     "3. CHECK “send credentials via email” → personal email *{personal_email}*\n"
     "4. CHECK “force password change on first login”\n"

--- a/Onboarding/provisioning.py
+++ b/Onboarding/provisioning.py
@@ -41,9 +41,11 @@ from slack_helpers import invite_to_workspace, notify_operators
 load_dotenv(dotenv_path="../.env")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-HARVEST_API_KEY = os.getenv("HARVEST_API_KEY")
-HARVEST_ACCOUNT_ID = os.getenv("HARVEST_ACCOUNT_ID")
-SLACK_TOKEN = os.getenv("SLACK_TOKEN")
+# .strip(): secret versions created with `echo` carry a trailing newline, which
+# is invalid in HTTP header values (bit us live on harvest-acc-id).
+HARVEST_API_KEY = (os.getenv("HARVEST_API_KEY") or "").strip()
+HARVEST_ACCOUNT_ID = (os.getenv("HARVEST_ACCOUNT_ID") or "").strip()
+SLACK_TOKEN = (os.getenv("SLACK_TOKEN") or "").strip()
 
 ZOHO_INSTRUCTIONS = (
     ":busts_in_silhouette: *Zoho user needed for {name}* (approved by {approver})\n"

--- a/Onboarding/provisioning.py
+++ b/Onboarding/provisioning.py
@@ -8,12 +8,16 @@ mark, and by a daily scheduler sweep that retries anything still pending.
 
 Per-hire steps, in the playbook order Zoho -> Slack -> Harvest:
 
-  1. Zoho has no API access yet -> NOTIFY-A-HUMAN: DM the operators the exact
-     playbook instructions (auto-gen password, credentials to the PERSONAL email,
-     force password change). A human then creates the user and clicks
-     "mark Zoho created" in the dashboard.
+  1. Zoho: create the work mailbox via the Zoho Mail API (Self Client of
+     hello@thirstysprout.ai; auto-generated password, forced change at first
+     login, role=member) and DM the operators the one-time credentials to
+     forward to the hire's PERSONAL email. If the API creds are missing or the
+     call fails, fall back to NOTIFY-A-HUMAN: DM the exact playbook instructions;
+     a human then creates the user and clicks "mark Zoho created" in the
+     dashboard.
   2. Slack + Harvest invites target the WORK email, which only exists once the
-     Zoho user is created — so both steps WAIT for accounts.zoho.created_at.
+     Zoho user is created — so both steps WAIT for accounts.zoho.created_at
+     (set in the same run when the API path succeeds).
      Slack: try the admin invite API, fall back to a manual-invite DM.
      Harvest: create the contractor (rate/cost from the approval form, 40h,
      Member) and assign to the approved project. A full plan (seat cap) never
@@ -37,6 +41,7 @@ from slack_sdk import WebClient
 from firestore_store import OnboardingStore, _now
 from harvest_client import HarvestClient, SeatLimitError
 from slack_helpers import invite_to_workspace, notify_operators
+from zoho_client import ZohoMailClient, generate_password
 
 load_dotenv(dotenv_path="../.env")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -46,6 +51,26 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 HARVEST_API_KEY = (os.getenv("HARVEST_API_KEY") or "").strip()
 HARVEST_ACCOUNT_ID = (os.getenv("HARVEST_ACCOUNT_ID") or "").strip()
 SLACK_TOKEN = (os.getenv("SLACK_TOKEN") or "").strip()
+ZOHO_CLIENT_ID = (os.getenv("ZOHO_CLIENT_ID") or "").strip()
+ZOHO_CLIENT_SECRET = (os.getenv("ZOHO_CLIENT_SECRET") or "").strip()
+ZOHO_REFRESH_TOKEN = (os.getenv("ZOHO_REFRESH_TOKEN") or "").strip()
+
+ZOHO_CREATED_MESSAGE = (
+    ":white_check_mark: *Zoho mailbox created for {name}*: *{work_email}* "
+    "(approved by {approver})\n"
+    "One-time password: `{password}` — the user MUST change it at first login.\n"
+    "Please send these credentials to the personal email *{personal_email}*, and the "
+    "onboarding guide to BOTH {work_email} and {personal_email}.\n"
+    "(This password is only shown here — it is not stored anywhere.)\n"
+    "Slack + Harvest invites to {work_email} are going out automatically now."
+)
+
+ZOHO_EXISTING_MESSAGE = (
+    ":information_source: *Zoho mailbox already exists* for *{name}* ({work_email}) — "
+    "marked as created and moving on to the Slack + Harvest invites. If the hire never "
+    "received credentials, reset their password from the Zoho admin console and send it "
+    "to *{personal_email}*."
+)
 
 ZOHO_INSTRUCTIONS = (
     ":busts_in_silhouette: *Zoho user needed for {name}* (approved by {approver})\n"
@@ -85,7 +110,8 @@ def _acct(doc, tool):
     return (doc.get("accounts") or {}).get(tool) or {}
 
 
-def provision_one(store: OnboardingStore, slack: WebClient, harvest: HarvestClient, doc):
+def provision_one(store: OnboardingStore, slack: WebClient, harvest: HarvestClient, doc,
+                  zoho: ZohoMailClient = None):
     """Run all still-pending steps for one hire. Returns a step->outcome dict."""
     person_id = doc["person_id"]
     req = doc.get("provision_request") or {}
@@ -102,21 +128,51 @@ def provision_one(store: OnboardingStore, slack: WebClient, harvest: HarvestClie
     name = doc.get("personal_name") or doc.get("contract_name") or person_id
     work_email = doc.get("email")
 
-    # --- 1. Zoho: notify-a-human (no API), once -------------------------------
+    # --- 1. Zoho mailbox: API first, notify-a-human as fallback ----------------
     if not _acct(doc, "zoho").get("created_at"):
-        if not _acct(doc, "zoho").get("requested_at"):
-            notify_operators(slack, ZOHO_INSTRUCTIONS.format(
-                name=name, approver=req.get("by", "?"), work_email=work_email,
-                personal_email=req.get("personal_email", "?")))
-            store.record_account_event(person_id, "zoho", {"requested_at": _now()},
-                                       action="zoho_manual_requested")
-            outcomes["zoho"] = "operators notified"
-        else:
-            outcomes["zoho"] = "waiting for manual creation"
-        # Work email doesn't exist until Zoho is done — hold the invites.
-        outcomes["slack"] = outcomes["harvest"] = "waiting for zoho.created_at"
-        return outcomes
-    outcomes["zoho"] = "created"
+        created = False
+        if zoho is not None:
+            try:
+                first, last = _split_name(doc)
+                if zoho.find_user_by_email(work_email):
+                    notify_operators(slack, ZOHO_EXISTING_MESSAGE.format(
+                        name=name, work_email=work_email,
+                        personal_email=req.get("personal_email", "?")))
+                    store.record_account_event(
+                        person_id, "zoho", {"created_at": _now(), "mode": "api_existing"},
+                        action="zoho_found_existing")
+                    outcomes["zoho"] = "already existed in Zoho (marked created)"
+                else:
+                    # The one-time password lives ONLY in the operator DM — never
+                    # in Firestore or logs. Forced change at first login.
+                    password = generate_password()
+                    zoho.create_user(work_email, first, last, password)
+                    store.record_account_event(
+                        person_id, "zoho", {"created_at": _now(), "mode": "api"},
+                        action="zoho_created_api")
+                    notify_operators(slack, ZOHO_CREATED_MESSAGE.format(
+                        name=name, approver=req.get("by", "?"), work_email=work_email,
+                        personal_email=req.get("personal_email", "?"), password=password))
+                    outcomes["zoho"] = "created via API"
+                created = True
+            except Exception as e:  # fall back to the human playbook DM
+                logging.error(f"Zoho API provisioning failed for {person_id}: {e}")
+                outcomes["zoho_api_error"] = str(e)[:200]
+        if not created:
+            if not _acct(doc, "zoho").get("requested_at"):
+                notify_operators(slack, ZOHO_INSTRUCTIONS.format(
+                    name=name, approver=req.get("by", "?"), work_email=work_email,
+                    personal_email=req.get("personal_email", "?")))
+                store.record_account_event(person_id, "zoho", {"requested_at": _now()},
+                                           action="zoho_manual_requested")
+                outcomes["zoho"] = "operators notified (manual fallback)"
+            else:
+                outcomes["zoho"] = "waiting for manual creation"
+            # Work email doesn't exist until Zoho is done — hold the invites.
+            outcomes["slack"] = outcomes["harvest"] = "waiting for zoho.created_at"
+            return outcomes
+    else:
+        outcomes["zoho"] = "created"
 
     # --- 2. Slack invite (work email) ------------------------------------------
     slack_acct = _acct(doc, "slack")
@@ -179,6 +235,12 @@ def run_provisioning(person_id=None):
     store = OnboardingStore()
     slack = WebClient(token=SLACK_TOKEN)
     harvest = HarvestClient(HARVEST_API_KEY, HARVEST_ACCOUNT_ID)
+    # Zoho creds are optional: without them the Zoho step degrades to the
+    # notify-a-human playbook DM instead of failing the whole run.
+    zoho = (ZohoMailClient(ZOHO_CLIENT_ID, ZOHO_CLIENT_SECRET, ZOHO_REFRESH_TOKEN)
+            if (ZOHO_CLIENT_ID and ZOHO_CLIENT_SECRET and ZOHO_REFRESH_TOKEN) else None)
+    if zoho is None:
+        logging.warning("ZOHO_* env not set — Zoho step will use the manual fallback")
 
     if person_id:
         doc = store.get(person_id)
@@ -190,7 +252,7 @@ def run_provisioning(person_id=None):
 
     results = {}
     for doc in docs:
-        results[doc["person_id"]] = provision_one(store, slack, harvest, doc)
+        results[doc["person_id"]] = provision_one(store, slack, harvest, doc, zoho=zoho)
     logging.info(f"Provisioning results: {results}")
     return results
 

--- a/Onboarding/zoho_client.py
+++ b/Onboarding/zoho_client.py
@@ -1,0 +1,113 @@
+"""
+Minimal Zoho Mail admin client for provisioning (create the work mailbox).
+
+Auth is a Self Client created by the org admin (hello@thirstysprout.ai) at
+api-console.zoho.com: a long-lived refresh token (Secret Manager) is exchanged
+for a ~1h access token on demand. Scope is ZohoMail.organization.accounts.ALL —
+enough to list/create org mailboxes, deliberately nothing wider.
+
+US data center (accounts.zoho.com / mail.zoho.com — where the org lives).
+The documented create endpoint is /api/organization/{zoid}/accounts, but the
+zoid-less form resolves to the token's own org for both GET and POST (verified
+live), which saves needing the organization.READ scope just to look up zoid.
+"""
+import secrets
+import string
+import time
+
+import requests
+
+ACCOUNTS_BASE = "https://accounts.zoho.com"
+MAIL_BASE = "https://mail.zoho.com"
+
+_PASSWORD_SPECIALS = "!@#$%^&*"
+
+
+def generate_password(length: int = 16) -> str:
+    """Zoho rules: ≥8 chars with upper + lower + digit + special (David's playbook)."""
+    alphabet = string.ascii_letters + string.digits + _PASSWORD_SPECIALS
+    while True:
+        pwd = "".join(secrets.choice(alphabet) for _ in range(length))
+        if (any(c.islower() for c in pwd) and any(c.isupper() for c in pwd)
+                and any(c.isdigit() for c in pwd) and any(c in _PASSWORD_SPECIALS for c in pwd)):
+            return pwd
+
+
+class ZohoMailClient:
+    def __init__(self, client_id: str, client_secret: str, refresh_token: str):
+        # .strip(): header/form values reject the trailing newline `echo`-created
+        # secret versions carry.
+        self.client_id = (client_id or "").strip()
+        self.client_secret = (client_secret or "").strip()
+        self.refresh_token = (refresh_token or "").strip()
+        self._access_token = None
+        self._expires_at = 0.0
+
+    def _token(self) -> str:
+        if self._access_token and time.time() < self._expires_at - 60:
+            return self._access_token
+        resp = requests.post(f"{ACCOUNTS_BASE}/oauth/v2/token", data={
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "refresh_token": self.refresh_token,
+        }, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if "access_token" not in data:
+            raise RuntimeError(f"Zoho token refresh failed: {data.get('error', 'no access_token')}")
+        self._access_token = data["access_token"]
+        self._expires_at = time.time() + int(data.get("expires_in", 3600))
+        return self._access_token
+
+    def _headers(self) -> dict:
+        return {"Authorization": f"Zoho-oauthtoken {self._token()}"}
+
+    def list_users(self):
+        users, start, limit = [], 1, 200
+        while True:
+            resp = requests.get(f"{MAIL_BASE}/api/organization/accounts",
+                                headers=self._headers(),
+                                params={"start": start, "limit": limit}, timeout=30)
+            resp.raise_for_status()
+            batch = resp.json().get("data") or []
+            users.extend(batch)
+            if len(batch) < limit:
+                return users
+            start += len(batch)
+
+    def find_user_by_email(self, email: str):
+        email = (email or "").lower()
+        for user in self.list_users():
+            addresses = {
+                (user.get("primaryEmailAddress") or "").lower(),
+                (user.get("mailboxAddress") or "").lower(),
+                (user.get("accountName") or "").lower(),
+            }
+            for entry in user.get("emailAddress") or []:
+                if isinstance(entry, dict):
+                    addresses.add((entry.get("mailId") or "").lower())
+            if email in addresses:
+                return user
+        return None
+
+    def create_user(self, email: str, first_name: str, last_name: str, password: str):
+        """
+        Create the org mailbox. oneTimePassword forces a password change at first
+        login (playbook rule). Raises on any non-2xx — the caller falls back to
+        the notify-a-human path.
+        """
+        body = {
+            "primaryEmailAddress": email,
+            "password": password,
+            "firstName": first_name,
+            "lastName": last_name,
+            "displayName": f"{first_name} {last_name}".strip(),
+            "role": "member",  # never admin for onboarded contractors
+            "oneTimePassword": True,
+        }
+        resp = requests.post(f"{MAIL_BASE}/api/organization/accounts",
+                             headers=self._headers(), json=body, timeout=60)
+        if resp.status_code not in (200, 201):
+            raise RuntimeError(f"Zoho create_user failed ({resp.status_code}): {resp.text[:300]}")
+        return (resp.json() or {}).get("data") or {}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -129,7 +129,7 @@ steps:
           --trigger-http \
           --no-allow-unauthenticated \
           --clear-env-vars \
-          --set-secrets SLACK_TOKEN=slack-token:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest \
+          --set-secrets SLACK_TOKEN=slack-token:latest,HARVEST_API_KEY=harvest-api-key:latest,HARVEST_ACCOUNT_ID=harvest-acc-id:latest,ZOHO_CLIENT_ID=zoho-client-id:latest,ZOHO_CLIENT_SECRET=zoho-client-secret:latest,ZOHO_REFRESH_TOKEN=zoho-refresh-token:latest \
           --entry-point provision_onboarding \
           --set-build-env-vars GOOGLE_FUNCTION_SOURCE=provisioning.py \
           --source=Onboarding \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,9 +5,6 @@ steps:
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
-        pip3 install -r Announcements/requirements.txt
         gcloud functions deploy post_message_to_slack_http \
           --region europe-west1 \
           --runtime python311 \
@@ -24,9 +21,6 @@ steps:
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
-        pip3 install -r Invoicing/requirements.txt
         gcloud functions deploy create_invoices_http \
           --region europe-west1 \
           --runtime python311 \
@@ -43,9 +37,6 @@ steps:
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
-        pip3 install -r Payroll/requirements.txt
         gcloud functions deploy process_payroll_http \
           --region europe-west1 \
           --runtime python311 \
@@ -63,9 +54,6 @@ steps:
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
-        pip3 install -r Payroll_Reminders/requirements.txt
         gcloud functions deploy send_timesheet_reminders \
           --region europe-west1 \
           --runtime python311 \
@@ -85,9 +73,6 @@ steps:
       - '-c'
       - |
         set -e
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
-        pip3 install -r Payroll/requirements.txt
         # PRIVATE: this is a gen2 (Cloud Run) function, which the org policy does
         # NOT block from going public — it previously had an allUsers invoker
         # binding. Deploy authenticated and strip any leftover allUsers binding;
@@ -115,12 +100,9 @@ steps:
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
         # Single source of truth: copy shared modules from Payroll into the
         # Onboarding source dir so --source=Onboarding packages them.
         cp Payroll/deel_client.py Payroll/matcher.py Onboarding/
-        pip3 install -r Onboarding/requirements.txt
         gcloud functions deploy backfill_onboarding \
           --region europe-west1 \
           --runtime python311 \
@@ -141,9 +123,6 @@ steps:
       - '-c'
       - |
         set -e
-        apt-get update && apt-get install -y python3 python3-pip
-        pip3 install --upgrade pip
-        pip3 install -r Onboarding/requirements.txt
         gcloud functions deploy provision_onboarding \
           --region europe-west1 \
           --runtime python311 \


### PR DESCRIPTION
The first post-merge deploy (build `fa037d4d`) failed at the sync_user_mappings step: `google/cloud-sdk:slim` now runs Debian trixie, where `pip3 install` into the system Python is rejected (PEP 668 externally-managed-environment).

Those `apt-get`/`pip3 install` preambles were vestigial — `gcloud functions deploy` installs each function's `requirements.txt` server-side — and had been failing **silently** in the old steps (no `set -e`). The hardened steps added in #14 correctly aborted on the failure.

This removes the preambles from all 7 function steps. Side effect: builds are several minutes faster.

Verification: redeployed from this branch (build submitted from local source) — see PR comment/conversation for the green build ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)